### PR TITLE
Modify Protocol from Hardcoded 'https' to Dynamic Scheme

### DIFF
--- a/src/internal/sqs.ts
+++ b/src/internal/sqs.ts
@@ -67,7 +67,7 @@ export class SQSClient extends AWSClient {
         const signedRequest: SignedHTTPRequest = this.signature.sign(
             {
                 method: 'POST',
-                protocol: 'https',
+                protocol: this.scheme,
                 hostname: this.host,
                 path: '/',
                 headers: {
@@ -130,7 +130,7 @@ export class SQSClient extends AWSClient {
         const signedRequest: SignedHTTPRequest = this.signature.sign(
             {
                 method: 'POST',
-                protocol: 'https',
+                protocol: this.scheme,
                 hostname: this.host,
                 path: '/',
                 headers: {


### PR DESCRIPTION
fix https://github.com/grafana/k6-jslib-aws/issues/49

I have tried to check the operation in my local environment.
In addition, I checked other Client classes and found that scheme can be set.