### PR TITLE
Update Webpack version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
                 "terser-webpack-plugin": "^5.3.1",
                 "typescript": "^4.9.5",
                 "uuid": "^3.4.0",
-                "webpack": "^5.72.0",
-                "webpack-cli": "^4.9.2",
+                "webpack": "^5.89.0",
+                "webpack-cli": "^5.1.4",
                 "webpack-glob-entries": "^1.0.1"
             }
         },
@@ -2626,34 +2626,42 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+            "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
             "dev": true,
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x",
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+            "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
             "dev": true,
-            "dependencies": {
-                "envinfo": "^7.7.3"
+            "engines": {
+                "node": ">=14.15.0"
             },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+            "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
             "dev": true,
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "webpack-dev-server": {
@@ -3524,9 +3532,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
-            "integrity": "sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.0.tgz",
+            "integrity": "sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -4650,12 +4658,12 @@
             }
         },
         "node_modules/interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true,
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/is-array-buffer": {
@@ -5595,15 +5603,15 @@
             }
         },
         "node_modules/rechoir": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dev": true,
             "dependencies": {
-                "resolve": "^1.9.0"
+                "resolve": "^1.20.0"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10.13.0"
             }
         },
         "node_modules/regenerate": {
@@ -6454,9 +6462,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.88.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
-            "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+            "version": "5.89.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+            "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -6501,42 +6509,40 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+            "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.2.0",
-                "@webpack-cli/info": "^1.5.0",
-                "@webpack-cli/serve": "^1.7.0",
+                "@webpack-cli/configtest": "^2.1.1",
+                "@webpack-cli/info": "^2.0.2",
+                "@webpack-cli/serve": "^2.0.5",
                 "colorette": "^2.0.14",
-                "commander": "^7.0.0",
+                "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^2.2.0",
-                "rechoir": "^0.7.0",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
                 "webpack-merge": "^5.7.3"
             },
             "bin": {
                 "webpack-cli": "bin/cli.js"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14.15.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x"
+                "webpack": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "@webpack-cli/generators": {
-                    "optional": true
-                },
-                "@webpack-cli/migrate": {
                     "optional": true
                 },
                 "webpack-bundle-analyzer": {
@@ -6548,12 +6554,12 @@
             }
         },
         "node_modules/webpack-cli/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
             "dev": true,
             "engines": {
-                "node": ">= 10"
+                "node": ">=14"
             }
         },
         "node_modules/webpack-glob-entries": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
         "terser-webpack-plugin": "^5.3.1",
         "typescript": "^4.9.5",
         "uuid": "^3.4.0",
-        "webpack": "^5.72.0",
-        "webpack-cli": "^4.9.2",
+        "webpack": "^5.89.0",
+        "webpack-cli": "^5.1.4",
         "webpack-glob-entries": "^1.0.1"
     },
     "engines": {},
     "scripts": {
-        "webpack": "webpack",
+        "webpack": "./node_modules/.bin/webpack",
         "test": "npm run webpack && docker-compose down && docker-compose up --build -d && sleep 15 && k6 run tests/index.js",
         "lint": "npx eslint src tests examples",
         "ci-test": "npm run webpack && k6 run tests/index.js"


### PR DESCRIPTION
It updates the Webpack-related dependencies to their latest version:
- `webpack` to `5.89.0`
- `webpack-cli` to `5.1.4`

Because (a) it's always good to keep dependencies updated, (b) they both have been there for some months for now, with no new updates, so I guess the risk is low, and (c) apparently each contributor has been using their own (globally installed) version of Webpack, so in some way the current version didn't have a very strong implication.

I've also modified the `webpack` command (executed with `npm run webpack`), to use the self-contained webpack version, instead of using it globally, which again shouldn't have big implications, but it's probably safer and more consistent.