### PR TITLE
fix: remove uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "k6-jslib-aws",
-    "version": "0.12.3",
+    "name": "@chocoapp/k6-jslib-aws",
+    "version": "0.12.3-choco",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "k6-jslib-aws",
-            "version": "0.12.3",
+            "name": "@chocoapp/k6-jslib-aws",
+            "version": "0.12.3-choco",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.4.4",
@@ -18,7 +18,6 @@
                 "@babel/preset-env": "^7.4.4",
                 "@babel/preset-typescript": "^7.16.7",
                 "@types/k6": "^0.45.0",
-                "@types/uuid": "^3.4.0",
                 "@types/webpack": "^5.28.0",
                 "@typescript-eslint/eslint-plugin": "^6.11.0",
                 "@typescript-eslint/parser": "^6.11.0",
@@ -30,7 +29,6 @@
                 "eslint-plugin-import": "^2.29.0",
                 "terser-webpack-plugin": "^5.3.1",
                 "typescript": "^4.9.5",
-                "uuid": "^3.4.0",
                 "webpack": "^5.89.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-glob-entries": "^1.0.1"
@@ -2194,12 +2192,6 @@
             "version": "7.5.8",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
             "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-            "dev": true
-        },
-        "node_modules/@types/uuid": {
-            "version": "3.4.13",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.13.tgz",
-            "integrity": "sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==",
             "dev": true
         },
         "node_modules/@types/webpack": {
@@ -6787,16 +6779,6 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "dev": true,
-            "bin": {
-                "uuid": "bin/uuid"
             }
         },
         "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-    "name": "k6-jslib-aws",
-    "repository": "https://github.com/grafana/k6-jslib-aws",
-    "version": "0.12.3",
+    "name": "@chocoapp/k6-jslib-aws",
+    "version": "0.12.3-choco",
     "description": "Create a distribution file for the aws jslib",
     "main": "src/index.js",
     "devDependencies": {
@@ -14,7 +13,6 @@
         "@babel/preset-env": "^7.4.4",
         "@babel/preset-typescript": "^7.16.7",
         "@types/k6": "^0.45.0",
-        "@types/uuid": "^3.4.0",
         "@types/webpack": "^5.28.0",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.11.0",
@@ -26,7 +24,6 @@
         "eslint-plugin-import": "^2.29.0",
         "terser-webpack-plugin": "^5.3.1",
         "typescript": "^4.9.5",
-        "uuid": "^3.4.0",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
         "webpack-glob-entries": "^1.0.1"

--- a/src/internal/secrets-manager.ts
+++ b/src/internal/secrets-manager.ts
@@ -1,13 +1,24 @@
 import { JSONArray, JSONObject } from 'k6'
 import http, { RefinedResponse, ResponseType } from 'k6/http'
 
-import { v4 as uuidv4 } from 'uuid'
 import { AWSClient } from './client'
 import { AWSConfig } from './config'
 import { AMZ_TARGET_HEADER } from './constants'
 import { AWSError } from './error'
 import { HTTPHeaders, HTTPMethod } from './http'
 import { InvalidSignatureError, SignatureV4 } from './signature'
+
+const fakeUuid = function () {
+    let result = ''
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    const charactersLength = characters.length
+    let counter = 0
+    while (counter < 32) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength))
+        counter += 1
+    }
+    return result
+}
 
 /**
  * Class allowing to interact with Amazon AWS's SecretsManager service
@@ -133,7 +144,7 @@ export class SecretsManagerClient extends AWSClient {
         versionID?: string,
         tags?: Array<object>
     ): Promise<Secret> {
-        versionID = versionID || uuidv4()
+        versionID = versionID || fakeUuid()
 
         const signedRequest = this.signature.sign(
             {
@@ -179,7 +190,7 @@ export class SecretsManagerClient extends AWSClient {
      * @throws {InvalidSignatureError}
      */
     async putSecretValue(id: string, secret: string, versionID?: string): Promise<Secret> {
-        versionID = versionID || uuidv4()
+        versionID = versionID || fakeUuid()
 
         const signedRequest = this.signature.sign(
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = {
         }),
     ],
     optimization: {
-        minimize: true,
+        minimize: false,
         minimizer: [new TerserPlugin()],
     },
 }


### PR DESCRIPTION
## Context
- k6 don't support UUID, so we remove it
- this repo is fork from the k6 aws js lib, we modify and re-publish for our e2e k6 test