### PR TITLE
Fix flaky s3 listbuckets test

### DIFF
--- a/tests/internal/s3.js
+++ b/tests/internal/s3.js
@@ -11,14 +11,14 @@ export async function s3TestSuite(data) {
     s3Client.endpoint = s3Endpoint
 
     await asyncDescribe('s3.listBuckets', async (expect) => {
-        let buckets;
+        let buckets
         // Act
         buckets = await s3Client.listBuckets()
 
         // Assert
         expect(buckets).to.be.an('array')
         // Because other tests may have created buckets, we can't assume there is only one bucket.
-        expect(buckets).to.have.lengthOf.above(1)
+        expect(buckets).to.have.lengthOf.least(1)
         expect(buckets.map((b) => b.name)).to.contain(data.s3.testBucketName)
     })
 


### PR DESCRIPTION
In this PR, we address flakiness in the `s3.listBuckets` test. We used the ChaiJS `above(1)` statement, which checked if the value was greater than 1, although it turned out it could also be 1. We thus switch to `least` which performs a greater than or equal operation on the value instead.