### PR TITLE
Add support for downloading binary files using `S3Client.getObject`

### DIFF
--- a/src/internal/s3.ts
+++ b/src/internal/s3.ts
@@ -1,4 +1,3 @@
-import { bytes } from 'k6'
 import { parseHTML } from 'k6/html'
 import http, { RefinedResponse, ResponseType } from 'k6/http'
 

--- a/src/internal/s3.ts
+++ b/src/internal/s3.ts
@@ -168,7 +168,11 @@ export class S3Client extends AWSClient {
      * @throws  {S3ServiceError}
      * @throws  {InvalidSignatureError}
      */
-    async getObject(bucketName: string, objectKey: string): Promise<S3Object> {
+    async getObject(
+        bucketName: string,
+        objectKey: string,
+        additionalHeaders: object = {}
+    ): Promise<S3Object> {
         // Prepare request
         const method = 'GET'
 
@@ -177,13 +181,27 @@ export class S3Client extends AWSClient {
                 method: method,
                 endpoint: this.endpoint,
                 path: encodeURI(`/${bucketName}/${objectKey}`),
-                headers: {},
+                headers: {
+                    ...additionalHeaders,
+                },
             },
             {}
         )
 
+        // If the Accept header is set to 'application/octet-stream', we want to
+        // return the response as binary data.
+        let responseType: ResponseType = 'text'
+        if (
+            'Accept' in additionalHeaders &&
+            additionalHeaders['Accept'] !== undefined &&
+            additionalHeaders['Accept'] === 'application/octet-stream'
+        ) {
+            responseType = 'binary'
+        }
+
         const res = await http.asyncRequest(method, signedRequest.url, null, {
             headers: signedRequest.headers,
+            responseType: responseType as ResponseType,
         })
         this.handleError(res, 'GetObject')
 
@@ -534,7 +552,7 @@ export class S3Object {
     etag: string
     size: number
     storageClass: StorageClass
-    data?: string | bytes | null
+    data?: string | ArrayBuffer | null
 
     /**
      * Create an S3 Object
@@ -544,7 +562,7 @@ export class S3Object {
      * @param  {string} etag - S3 object's etag
      * @param  {number} size - S3 object's size
      * @param  {StorageClass} storageClass - S3 object's storage class
-     * @param  {string | bytes | null} data=null - S3 Object's data
+     * @param  {string | ArrayBuffer | null} data=null - S3 Object's data
      */
     constructor(
         key: string,
@@ -552,7 +570,7 @@ export class S3Object {
         etag: string,
         size: number,
         storageClass: StorageClass,
-        data?: string | bytes | null
+        data?: string | ArrayBuffer | null
     ) {
         this.key = key
         this.lastModified = lastModified

--- a/tests/internal/s3.js
+++ b/tests/internal/s3.js
@@ -73,6 +73,21 @@ export async function s3TestSuite(data) {
         expect(getNonExistingObjectError).to.be.an.instanceOf(S3ServiceError)
     })
 
+    await asyncDescribe('s3.getObject [binary]', async (expect) => {
+        // Act
+        const gotBinaryObject = await s3Client.getObject(
+            data.s3.testBucketName,
+            data.s3.testObjects[0].key,
+            { Accept: 'application/octet-stream' }
+        )
+
+        // Assert
+        expect(gotBinaryObject).to.be.an('object')
+        expect(gotBinaryObject.key).to.equal(data.s3.testObjects[0].key)
+        expect(gotBinaryObject.data).to.be.an('ArrayBuffer')
+        expect(gotBinaryObject.data.byteLength).to.equal(data.s3.testObjects[0].body.length)
+    })
+
     await asyncDescribe('s3.putObject', async (expect) => {
         // Act
         let putObectError


### PR DESCRIPTION
# What

This Pull Request adds support for downloading binary S3 objects using the `getObject` operation to address #105 and supersede #107.

We wanted to get this done, and as the initial contributor did not appear to have the capacity to switch to the proposed design, we took the liberty to do it.

# How

This PR adds an `additionalHeaders` parameter to S3Client.getObject. The operation additionally receives support for the `Accept` header. When the header is provided with the value `application/octet-stream,` the operation will treat the response as binary content and return an ArrayBuffer.

We decided to opt for the header approach, as it doesn't leak nor depend on k6 interfaces and adopts a standard HTTP behavior, indicating to the server the type of content we expect in return through the Accept header.

## Example

```javascript
// ...

export default async function () {
    await s3.getObject(testBucketName, testFileKey, {
        Accept: 'application/octet-stream',
    })
    
    // ...
}
```