### PR TITLE
Disregard `K6_DISCARD_RESPONSE_BODIES`

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1,4 +1,4 @@
-import { RefinedResponse, ResponseType } from 'k6/http'
+import { RefinedResponse, ResponseType, Params } from 'k6/http'
 
 import { AWSConfig } from './config'
 import { Endpoint } from './endpoint'
@@ -26,6 +26,22 @@ import {
 export class AWSClient {
     readonly awsConfig: AWSConfig
     readonly serviceName: string
+
+    // Because jslib-aws is mostly used as a way to setup or feed k6 tests, and
+    // we want the jslib-aws to be able to disregard k6's discardResponseBodies: meaning
+    // that for instance, even when setting discardResponseBodies to true in the k6 options, using
+    // s3.getObject still receives the underlying response body and returns data to the user.
+    //
+    // To achieve this, we set the responseType to 'text' in the baseRequestParams, as it
+    // will lead the http module to ignore the discardResponseBodies option.
+    //
+    // AWS Client classes can override this value if they want to receive the response body
+    // as a different type ('binary' for instance, e.g. S3Client.getObject).
+    //
+    // See #45: import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js'
+    readonly baseRequestParams: Params = {
+        responseType: 'text',
+    }
 
     private _endpoint?: Endpoint
 

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -38,7 +38,7 @@ export class AWSClient {
     // AWS Client classes can override this value if they want to receive the response body
     // as a different type ('binary' for instance, e.g. S3Client.getObject).
     //
-    // See #45: import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js'
+    // See #45: https://github.com/grafana/k6-jslib-aws/issues/45
     readonly baseRequestParams: Params = {
         responseType: 'text',
     }

--- a/src/internal/event-bridge.ts
+++ b/src/internal/event-bridge.ts
@@ -68,6 +68,7 @@ export class EventBridgeClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, EventBridgeOperation.PutEvents)

--- a/src/internal/kinesis.ts
+++ b/src/internal/kinesis.ts
@@ -278,6 +278,7 @@ export class KinesisClient extends AWSClient {
         )
 
         const res = await http.asyncRequest('POST', signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
 

--- a/src/internal/kms.ts
+++ b/src/internal/kms.ts
@@ -67,6 +67,7 @@ export class KMSClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, KMSOperation.ListKeys)
@@ -112,6 +113,7 @@ export class KMSClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, KMSOperation.GenerateDataKey)

--- a/src/internal/lambda.ts
+++ b/src/internal/lambda.ts
@@ -79,6 +79,7 @@ export class LambdaClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res)

--- a/src/internal/s3.ts
+++ b/src/internal/s3.ts
@@ -61,6 +61,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'ListBuckets')
@@ -120,6 +121,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'ListObjectsV2')
@@ -183,6 +185,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'GetObject')
@@ -241,6 +244,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'PutObject')
@@ -270,6 +274,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'DeleteObject')
@@ -309,6 +314,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
 
@@ -343,6 +349,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'CreateMultipartUpload')
@@ -393,6 +400,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'UploadPart')
@@ -443,6 +451,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'CompleteMultipartUpload')
@@ -477,6 +486,7 @@ export class S3Client extends AWSClient {
         )
 
         const res = await http.asyncRequest(method, signedRequest.url, signedRequest.body || null, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, 'AbortMultipartUpload')

--- a/src/internal/secrets-manager.ts
+++ b/src/internal/secrets-manager.ts
@@ -68,6 +68,7 @@ export class SecretsManagerClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, SecretsManagerOperation.ListSecrets)
@@ -100,6 +101,7 @@ export class SecretsManagerClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
 
@@ -160,6 +162,7 @@ export class SecretsManagerClient extends AWSClient {
         // headers['X-Amz-Target'] = `${this.serviceName}.CreateSecret`
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, SecretsManagerOperation.CreateSecret)
@@ -200,6 +203,7 @@ export class SecretsManagerClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, SecretsManagerOperation.PutSecretValue)
@@ -249,6 +253,7 @@ export class SecretsManagerClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, SecretsManagerOperation.DeleteSecret)

--- a/src/internal/sqs.ts
+++ b/src/internal/sqs.ts
@@ -207,6 +207,7 @@ export class SQSClient extends AWSClient {
         )
 
         const res = await http.asyncRequest('POST', signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
 

--- a/src/internal/ssm.ts
+++ b/src/internal/ssm.ts
@@ -71,6 +71,7 @@ export class SystemsManagerClient extends AWSClient {
         )
 
         const res = await http.asyncRequest(this.method, signedRequest.url, signedRequest.body, {
+            ...this.baseRequestParams,
             headers: signedRequest.headers,
         })
         this.handleError(res, SystemsManagerOperation.GetParameter)


### PR DESCRIPTION
## What

This Pull Request addresses #45, namely ignoring k6's `discardResponseBodies` and always returning response bodies obtained from jslib-aws HTTP calls.

## How

In this PR, we introduce a `baseRequestParams` member in the `AWSClient` class, which we add to every request made by children class implementations.

Using the `baseRequestParams` we set the default responseType for children implementation, allowing us to effectively disregard the http discardResponseBodies option. We can still, locally, override it where necessary, as in `S3Client.getObject`, for instance.

## Demo

The following script:
```javascript
//... 

export default async function () {
    // List the buckets the AWS authentication configuration
    // gives us access to.
    const buckets = await s3.listBuckets()

    console.log(JSON.stringify(buckets))

    const responseWithBody = http.get('https://httpbin.org/get')
    console.log(responseWithBody.body)
}
```

Will display something along the lines of:
```
[INFO] {"some": "content"}
[INFO] []
```

## References

closes #45 