### PR TITLE
✨ build typescript types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent coding styles
+#   between different editors and IDEs
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 80
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
               run: |
                   set -x
                   VERSION="${GITHUB_REF##*/}"
-                  npm run webpack && tar -zcf "k6-jslib-aws-${VERSION}.tar.gz" -C dist .
+                  npm run build && tar -zcf "k6-jslib-aws-${VERSION}.tar.gz" -C dist .
             - name: Create release with assets
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If the jslib-aws does not support the service you need yet, the best way to get 
 8. If the tests depend on a specific pre-existing state of the localstack setup, you can add a dedicated script in the `tests/internal/localstack_init` folder. Localstack will execute all the commands present in this script during its setup phase.
 9. The `npm test` command runs the test suite. This command will build the project and run the tests against the spun-up localstack docker container. The `docker-compose.yml` file contains the configuration for the container.
 10. Once the tests pass, the `src/index.ts` file should export the service class in the `src/index.ts` file so the user can use it.
-11. To get the build system to produce a build of your new service, run `npm run webpack`. Make sure that you commit the new build-related files too.
+11. To get the build system to produce a build of your new service, run `npm run build`. Make sure that you commit the new build-related files too.
 
 ### Publishing a new version
 
@@ -39,9 +39,9 @@ If the jslib-aws does not support the service you need yet, the best way to get 
 1. The service should have tests.
 2. The service should have documentation.
 3. The service should be re-exported in the `src/index.ts` file.
-4. The service should be exposed in the `aws.js` file in the `dist` directory when running the `npm run webpack` command.
-5. The service should produce a dedicated `{service-name}.js` file in the `dist` directory when running the `npm run webpack` command.
-6. The service should produce source map files for the dedicated `{service-name}.js` file and the `aws.js` file in the `dist` directory when running the `npm run webpack` command.
+4. The service should be exposed in the `aws.js` file in the `dist` directory when running the `npm run build` command.
+5. The service should produce a dedicated `{service-name}.js` file in the `dist` directory when running the `npm run build` command.
+6. The service should produce source map files for the dedicated `{service-name}.js` file and the `aws.js` file in the `dist` directory when running the `npm run build` command.
 
 #### Steps
 
@@ -51,7 +51,7 @@ In a PR:
 
 1. Bump the version in the `package.json` file.
 2. Run the `npm update` command to update the `package-lock.json` file.
-3. Run the `npm run webpack` command to ensure the build system produces the latest distributable files.
+3. Run the `npm run build` command to ensure the build system produces the latest distributable files.
 4. Search and replace every occurrence of the previous version in the `README.md` file with the new version.
 5. Search and replace every occurrence of the previous version in the `/examples` directory with the new version.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The scope of this library is intentionally minimal, focusing on the use cases ne
 npm install
 
 # Bundle the library in preparation for publication
-npm run webpack
+npm run build
 
 # Run the tests
 npm test

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     },
     "engines": {},
     "scripts": {
-        "webpack": "./node_modules/.bin/webpack",
-        "test": "npm run webpack && docker-compose down -v && docker-compose up --build -d && sleep 15 && k6 run -q tests/index.js",
-        "test:ci": "npm run webpack && k6 run -q tests/index.js",
+        "build": "npm run build:js && npm run build:types",
+        "build:js": "./node_modules/.bin/webpack",
+        "build:types": "tsc --project tsconfig.build.json --emitDeclarationOnly",
+        "test": "npm run build:js && docker-compose down -v && docker-compose up --build -d && sleep 15 && k6 run -q tests/index.js",
+        "test:ci": "npm run build && k6 run -q tests/index.js",
         "lint": "npx eslint src tests examples"
     },
     "keywords": [

--- a/src/internal/secrets-manager.ts
+++ b/src/internal/secrets-manager.ts
@@ -1,5 +1,6 @@
 import { JSONArray, JSONObject } from 'k6'
 import http, { RefinedResponse, ResponseType } from 'k6/http'
+// @ts-expect-error k6-utils doesn't have types yet
 import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js'
 
 import { AWSClient } from './client'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    "extends": ["./tsconfig.json"],
+    "compilerOptions": {
+        "noEmit": false,
+        "declaration": true,
+        "baseUrl": "./"
+    },
+    "include": ["src/"],
+    "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+      "outDir": "dist/",
+        
       "target": "es5",
       "moduleResolution": "node",
       "module": "commonjs",
@@ -12,7 +14,6 @@
       "noImplicitThis": true,
   
       "noUnusedLocals": true,
-      "noUnusedParameters": true,
       "noImplicitReturns": true,
       "noFallthroughCasesInSwitch": true,
   


### PR DESCRIPTION
This is a WIP PR to generate Typescript types from the source files, as suggested [here](https://github.com/grafana/k6-jslib-aws/issues/64#issuecomment-2464844747). 

**However, as is, these types would not be useful as they would not be distributed with the JS via the CDN.** 

There are a few possible solutions to work around this: 

- Update the CDN to support the [`X-TypeScript-Types` header from Deno](https://docs.deno.com/runtime/reference/ts_config_migration/#x-typescript-types), as I described [here](https://github.com/grafana/k6-jslib-aws/issues/118#issuecomment-2637926616). This does have the downside of not being native to Typescript though (and requiring an extra editor extension because of that). 
- Add the generated types to the `@types/k6` package, under a `declare module`. This would require altering the generated types from this PR to enable embedding like that.