### PR TITLE
Add S3UploadObject type and return it from s3.putObject operation

### DIFF
--- a/src/s3.ts
+++ b/src/s3.ts
@@ -15,6 +15,7 @@ export {
     S3Client,
     S3MultipartUpload,
     S3Object,
+    S3UploadedObject,
     S3Part,
     S3ServiceError,
 } from './internal/s3'

--- a/tests/internal/s3.js
+++ b/tests/internal/s3.js
@@ -90,9 +90,11 @@ export async function s3TestSuite(data) {
 
     await asyncDescribe('s3.putObject', async (expect) => {
         // Act
+        let putUploadedObject;
         let putObectError
+
         try {
-            await s3Client.putObject(
+            putUploadedObject = await s3Client.putObject(
                 data.s3.testBucketName,
                 'created-by-test.txt',
                 'This file was created by a test'
@@ -103,6 +105,11 @@ export async function s3TestSuite(data) {
 
         // Assert
         expect(putObectError).to.be.undefined
+        expect(putUploadedObject).to.be.an('object')
+        expect(putUploadedObject).to.have.property('key')
+        expect(putUploadedObject.key).to.equal('created-by-test.txt')
+        expect(putUploadedObject).to.have.property('etag')
+        expect(putUploadedObject.etag).to.be.a('string')
     })
 
     await asyncDescribe('s3.deleteObject', async (expect) => {


### PR DESCRIPTION
This PR is a work in progress, that aims to start tackling #121, and returns some elements of the S3 response when using the `putObject` operation.

How to test this PR:
1. clone the repo
2. `npm install`
3. `npm run webpack` compiles the library into `dist/index.js`
4. create a test using the following aws config (localstack):
```
const awsConfig = new AWSConfig({
    // Localstack runs on localhost:4566
    endpoint: 'http://localhost.localstack.cloud:4566',

    // Localstack is setup to use the us-east-1 region
    region: 'us-east-1',

    // Dummy value to keep the client happy
    accessKeyId: 'RUSZHYJUBIXGH4A5AAIX',

    // Dummy value to keep the client happy
    secretAccessKey: '9g7dpx9QU4XNawNHkMnXUQ6LgTfZIPG6fnIdADDQ',

    // Dummy value to keep the client happy
    sessionToken: 'sessiontoken',
})
```
5. Start the docker compose stack: `docker-compose up --build`
6. `k6 run my-example-script.js` 