### PR TITLE
Refactor: Denoify the codebase and checks

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,6 +1,4 @@
 import { build } from 'esbuild';
-import * as process from 'node:process'
-
 
 const buildOptions = {
     // Produce the build results in the dist folder
@@ -46,7 +44,7 @@ const buildOptions = {
 };
 
 // Determine if this is a release build or a development build
-if (process.env.NODE_ENV === 'production') {
+if (Deno.env.get('NODE_ENV') === 'production') {
     // Setup release build options
     Object.assign(buildOptions, {
         // Minify the output files
@@ -58,4 +56,10 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // Build the project
-build(buildOptions).catch(() => process.exit(1))
+try {
+    await build(buildOptions);
+    console.log('✅ Build completed successfully');
+} catch (error) {
+    console.error('❌ Build failed:', error);
+    Deno.exit(1);
+}

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,6 @@
     "@types/k6": "npm:@types/k6@^1.0.2",
     "esbuild": "npm:esbuild@^0.24.0",
     "eslint": "npm:eslint@^9.27.0",
-    "k6": "npm:@types/k6@^1.0.2"
+    "k6": "npm:@types/k6@^1.0.x"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,6 @@
     "@types/k6": "npm:@types/k6@^1.0.2",
     "esbuild": "npm:esbuild@^0.24.0",
     "eslint": "npm:eslint@^9.27.0",
-    "k6": "npm:k6@^0.0.0"
+    "k6": "npm:@types/k6@^1.0.2"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -5,8 +5,7 @@
     "jsr:@std/internal@^1.0.5": "1.0.5",
     "npm:@types/k6@^1.0.2": "1.0.2",
     "npm:esbuild@0.24": "0.24.2",
-    "npm:eslint@^9.27.0": "9.27.0",
-    "npm:k6@^0.0.0": "0.0.0"
+    "npm:eslint@^9.27.0": "9.27.0"
   },
   "jsr": {
     "@std/assert@1.0.11": {
@@ -504,9 +503,6 @@
     "json-stable-stringify-without-jsonify@1.0.1": {
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
-    "k6@0.0.0": {
-      "integrity": "sha512-GAQSWayS2+LjbH5bkRi+pMPYyP1JSp7o+4j58ANZ762N/RH/SdlAT3CHHztnn8s/xgg8kYNM24Gd2IPo9b5W+g=="
-    },
     "keyv@4.5.4": {
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": [
@@ -634,8 +630,7 @@
       "jsr:@std/assert@1",
       "npm:@types/k6@^1.0.2",
       "npm:esbuild@0.24",
-      "npm:eslint@^9.27.0",
-      "npm:k6@^0.0.0"
+      "npm:eslint@^9.27.0"
     ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,22 +1,10 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.11",
-    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "npm:@types/k6@1": "1.0.2",
     "npm:@types/k6@^1.0.2": "1.0.2",
     "npm:esbuild@0.24": "0.24.2",
     "npm:eslint@^9.27.0": "9.27.0"
-  },
-  "jsr": {
-    "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
-      "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/internal@1.0.5": {
-      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
-    }
   },
   "npm": {
     "@esbuild/aix-ppc64@0.24.2": {
@@ -628,6 +616,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
+      "npm:@types/k6@1",
       "npm:@types/k6@^1.0.2",
       "npm:esbuild@0.24",
       "npm:eslint@^9.27.0"

--- a/src/event-bridge.ts
+++ b/src/event-bridge.ts
@@ -1,4 +1,4 @@
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -7,9 +7,9 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
+} from "./internal/error.ts";
 export {
   EventBridgeClient,
   EventBridgeServiceError,
-} from "./internal/event-bridge";
-export { InvalidSignatureError } from "./internal/signature";
+} from "./internal/event-bridge.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,28 +7,28 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AMZ_CONTENT_SHA256_HEADER,
   UNSIGNED_PAYLOAD,
-} from "./internal/constants";
-export { KMSClient, KMSDataKey, KMSServiceError } from "./internal/kms";
-export { Endpoint } from "./internal/endpoint";
-export { SignatureV4 } from "./internal/signature";
-export { S3Bucket, S3Client, S3Object, S3ServiceError } from "./internal/s3";
+} from "./internal/constants.ts";
+export { KMSClient, KMSDataKey, KMSServiceError } from "./internal/kms.ts";
+export { Endpoint } from "./internal/endpoint.ts";
+export { SignatureV4 } from "./internal/signature.ts";
+export { S3Bucket, S3Client, S3Object, S3ServiceError } from "./internal/s3.ts";
 export {
   Secret,
   SecretsManagerClient,
   SecretsManagerServiceError,
-} from "./internal/secrets-manager";
+} from "./internal/secrets-manager.ts";
 export {
   SystemsManagerClient,
   SystemsManagerParameter,
   SystemsManagerServiceError,
-} from "./internal/ssm";
-export { ReceivedMessage, SQSClient } from "./sqs";
-export { KinesisClient } from "./internal/kinesis";
-export { EventBridgeClient } from "./internal/event-bridge";
-export { LambdaClient, LambdaInvocationError } from "./lambda";
+} from "./internal/ssm.ts";
+export { ReceivedMessage, SQSClient } from "./sqs.ts";
+export { KinesisClient } from "./internal/kinesis.ts";
+export { EventBridgeClient } from "./internal/event-bridge.ts";
+export { LambdaClient, LambdaInvocationError } from "./lambda.ts";

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1,8 +1,8 @@
-import { Params, RefinedResponse, ResponseType } from "k6/http";
+import { type Params, type RefinedResponse, type ResponseType } from "k6/http";
 
-import { AWSConfig } from "./config";
-import { Endpoint } from "./endpoint";
-import { HTTPHeaders } from "./http";
+import { AWSConfig } from "./config.ts";
+import { Endpoint } from "./endpoint.ts";
+import { HTTPHeaders } from "./http.ts";
 import {
   DNSError,
   DNSErrorKind,
@@ -14,7 +14,7 @@ import {
   TCPErrorKind,
   TLSError,
   TLSErrorKind,
-} from "./error";
+} from "./error.ts";
 
 /**
  * Class allowing to build requests targeting AWS APIs

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,5 +1,5 @@
-import { HTTPScheme } from "./http";
-import { Endpoint } from "./endpoint";
+import { HTTPScheme } from "./http.ts";
+import { Endpoint } from "./endpoint.ts";
 
 /** Class holding an AWS connection information */
 export class AWSConfig {

--- a/src/internal/error.ts
+++ b/src/internal/error.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "./json";
+import { JSONObject } from "./json.ts";
 import { parseHTML } from "k6/html";
 import { Response } from "k6/http";
 
@@ -72,7 +72,7 @@ export class AWSError extends Error {
 export class NetworkError<N extends NetworkErrorName, K extends ErrorKind>
   extends Error {
   code: K;
-  name: N;
+  override name: N;
 
   /**
    * Create a NetworkError

--- a/src/internal/event-bridge.ts
+++ b/src/internal/event-bridge.ts
@@ -1,12 +1,12 @@
-import http, { RefinedResponse, ResponseType } from "k6/http";
+import http, { type RefinedResponse, type ResponseType } from "k6/http";
 
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { AWSError } from "./error";
-import { JSONObject } from "./json";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { HTTPHeaders, HTTPMethod } from "./http";
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { AWSError } from "./error.ts";
+import { JSONObject } from "./json.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { HTTPHeaders, HTTPMethod } from "./http.ts";
 
 /**
  * Class allowing to interact with Amazon AWS's Event Bridge service
@@ -79,7 +79,7 @@ export class EventBridgeClient extends AWSClient {
     this.handleError(res, EventBridgeOperation.PutEvents);
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/http.ts
+++ b/src/internal/http.ts
@@ -1,4 +1,4 @@
-import { Endpoint } from "./endpoint";
+import { Endpoint } from "./endpoint.ts";
 
 /**
  * Type representing HTTP schemes

--- a/src/internal/kinesis.ts
+++ b/src/internal/kinesis.ts
@@ -1,13 +1,13 @@
 import http, { RefinedResponse, ResponseType } from "k6/http";
 
-import { AWSClient } from "./client";
+import { AWSClient } from "./client.ts";
 
-import { AWSConfig } from "./config";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { AWSError } from "./error";
-import { JSONObject } from "./json";
-import { HTTPHeaders } from "./http";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
+import { AWSConfig } from "./config.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { AWSError } from "./error.ts";
+import { JSONObject } from "./json.ts";
+import { HTTPHeaders } from "./http.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
 
 /**
 This API is based on
@@ -295,7 +295,7 @@ export class KinesisClient extends AWSClient {
     return res;
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/kms.ts
+++ b/src/internal/kms.ts
@@ -1,12 +1,12 @@
 import { JSONArray, JSONObject } from "k6";
 import http, { RefinedResponse, ResponseType } from "k6/http";
 
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { AWSError } from "./error";
-import { HTTPHeaders, HTTPMethod } from "./http";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { AWSError } from "./error.ts";
+import { HTTPHeaders, HTTPMethod } from "./http.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
 
 /**
  * Class allowing to interact with Amazon AWS's KMS service
@@ -131,7 +131,7 @@ export class KMSClient extends AWSClient {
     return KMSDataKey.fromJSON(res.json() as JSONObject);
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/lambda.ts
+++ b/src/internal/lambda.ts
@@ -1,12 +1,12 @@
 import http, { RefinedResponse, ResponseType } from "k6/http";
 import encoding from "k6/encoding";
 
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { AWSError } from "./error";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { HTTPHeaders, HTTPMethod, QueryParameterBag } from "./http";
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { AWSError } from "./error.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { HTTPHeaders, HTTPMethod, QueryParameterBag } from "./http.ts";
 
 /**
  * Class allowing to interact with Amazon AWS's Lambda service
@@ -107,7 +107,7 @@ export class LambdaClient extends AWSClient {
     }
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/s3.ts
+++ b/src/internal/s3.ts
@@ -1,11 +1,11 @@
 import { parseHTML } from "k6/html";
 import http, { RefinedResponse, ResponseType } from "k6/http";
 
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { AWSError } from "./error";
-import { SignedHTTPRequest } from "./http";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { AWSError } from "./error.ts";
+import { SignedHTTPRequest } from "./http.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
 
 /** Class allowing to interact with Amazon AWS's S3 service */
 export class S3Client extends AWSClient {
@@ -571,7 +571,7 @@ export class S3Client extends AWSClient {
     this.handleError(res, "AbortMultipartUpload");
   }
 
-  handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/secrets-manager.ts
+++ b/src/internal/secrets-manager.ts
@@ -145,7 +145,7 @@ export class SecretsManagerClient extends AWSClient {
     versionID?: string,
     tags?: Array<object>,
   ): Promise<Secret> {
-    versionID = versionID ?? uuidv4(true);
+    versionID = versionID ?? crypto.randomUUID();
 
     const signedRequest = this.signature.sign(
       {
@@ -201,7 +201,7 @@ export class SecretsManagerClient extends AWSClient {
     secret: string,
     versionID?: string,
   ): Promise<Secret> {
-    versionID = versionID ?? uuidv4(true);
+    versionID = versionID ?? crypto.randomUUID();
 
     const signedRequest = this.signature.sign(
       {

--- a/src/internal/secrets-manager.ts
+++ b/src/internal/secrets-manager.ts
@@ -1,13 +1,12 @@
 import { JSONArray, JSONObject } from "k6";
 import http, { RefinedResponse, ResponseType } from "k6/http";
-import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { AWSError } from "./error";
-import { HTTPHeaders, HTTPMethod } from "./http";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { AWSError } from "./error.ts";
+import { HTTPHeaders, HTTPMethod } from "./http.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
 
 /**
  * Class allowing to interact with Amazon AWS's SecretsManager service
@@ -291,7 +290,7 @@ export class SecretsManagerClient extends AWSClient {
     this.handleError(res, SecretsManagerOperation.DeleteSecret);
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/signature.ts
+++ b/src/internal/signature.ts
@@ -1,16 +1,16 @@
 import crypto from "k6/crypto";
 import { bytes } from "k6";
 
-import * as constants from "./constants";
-import { AWSError } from "./error";
+import * as constants from "./constants.ts";
+import { AWSError } from "./error.ts";
 import {
   hasHeader,
   HTTPHeaderBag,
   HTTPRequest,
   QueryParameterBag,
   SignedHTTPRequest,
-} from "./http";
-import { isArrayBuffer } from "./utils";
+} from "./http.ts";
+import { isArrayBuffer } from "./utils.ts";
 
 /**
  * SignatureV4 can be used to sign HTTP requests and presign URLs using the AWS Signature

--- a/src/internal/sqs.ts
+++ b/src/internal/sqs.ts
@@ -1,11 +1,12 @@
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
-import { HTTPHeaders } from "./http";
 import http, { RefinedResponse, ResponseType } from "k6/http";
-import { AWSError } from "./error";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { JSONArray, JSONObject } from "./json";
+
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
+import { HTTPHeaders } from "./http.ts";
+import { AWSError } from "./error.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { JSONArray, JSONObject } from "./json.ts";
 
 export class SQSClient extends AWSClient {
   private readonly signature: SignatureV4;
@@ -325,7 +326,7 @@ export class SQSClient extends AWSClient {
     }
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/internal/ssm.ts
+++ b/src/internal/ssm.ts
@@ -1,12 +1,12 @@
 import { JSONObject } from "k6";
 import http, { RefinedResponse, ResponseType } from "k6/http";
 
-import { AWSClient } from "./client";
-import { AWSConfig } from "./config";
-import { AMZ_TARGET_HEADER } from "./constants";
-import { AWSError } from "./error";
-import { HTTPHeaders, HTTPMethod } from "./http";
-import { InvalidSignatureError, SignatureV4 } from "./signature";
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { AWSError } from "./error.ts";
+import { HTTPHeaders, HTTPMethod } from "./http.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
 
 /**
  * Class allowing to interact with Amazon AWS's Systems Manager service
@@ -84,7 +84,7 @@ export class SystemsManagerClient extends AWSClient {
     return SystemsManagerParameter.fromJSON(res.json() as JSONObject);
   }
 
-  protected handleError(
+  protected override handleError(
     response: RefinedResponse<ResponseType | undefined>,
     operation?: string,
   ): boolean {

--- a/src/kinesis.ts
+++ b/src/kinesis.ts
@@ -1,4 +1,4 @@
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -7,6 +7,6 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
-export { KinesisClient, KinesisServiceError } from "./internal/kinesis";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
+export { KinesisClient, KinesisServiceError } from "./internal/kinesis.ts";

--- a/src/kms.ts
+++ b/src/kms.ts
@@ -1,5 +1,5 @@
 // Re-Export public symbols
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -8,6 +8,6 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { KMSClient, KMSDataKey, KMSServiceError } from "./internal/kms";
-export { InvalidSignatureError } from "./internal/signature";
+} from "./internal/error.ts";
+export { KMSClient, KMSDataKey, KMSServiceError } from "./internal/kms.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,5 +1,5 @@
 // Re-Export public symbols
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -8,6 +8,6 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
-export { LambdaClient, LambdaInvocationError } from "./internal/lambda";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
+export { LambdaClient, LambdaInvocationError } from "./internal/lambda.ts";

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,5 +1,5 @@
 // Re-Export public symbols
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -8,8 +8,8 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
 export {
   S3Bucket,
   S3Client,
@@ -18,4 +18,4 @@ export {
   S3Part,
   S3ServiceError,
   S3UploadedObject,
-} from "./internal/s3";
+} from "./internal/s3.ts";

--- a/src/secrets-manager.ts
+++ b/src/secrets-manager.ts
@@ -1,5 +1,5 @@
 // Re-Export public symbols
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -8,10 +8,10 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
 export {
   Secret,
   SecretsManagerClient,
   SecretsManagerServiceError,
-} from "./internal/secrets-manager";
+} from "./internal/secrets-manager.ts";

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -13,8 +13,8 @@ export {
   HOST_HEADER,
   SIGNING_ALGORITHM_IDENTIFIER,
   UNSIGNED_PAYLOAD,
-} from "./internal/constants";
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+} from "./internal/constants.ts";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -23,7 +23,7 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { Endpoint } from "./internal/endpoint";
-export { InvalidSignatureError } from "./internal/signature";
-export { SignatureV4 } from "./internal/signature";
+} from "./internal/error.ts";
+export { Endpoint } from "./internal/endpoint.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
+export { SignatureV4 } from "./internal/signature.ts";

--- a/src/sqs.ts
+++ b/src/sqs.ts
@@ -1,5 +1,5 @@
 // Re-Export public symbols
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -8,6 +8,6 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
-export { ReceivedMessage, SQSClient, SQSServiceError } from "./internal/sqs";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
+export { ReceivedMessage, SQSClient, SQSServiceError } from "./internal/sqs.ts";

--- a/src/ssm.ts
+++ b/src/ssm.ts
@@ -1,5 +1,5 @@
 // Re-export public symbols
-export { AWSConfig, InvalidAWSConfigError } from "./internal/config";
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
 export {
   AWSError,
   DNSError,
@@ -8,10 +8,10 @@ export {
   NetworkError,
   TCPError,
   TLSError,
-} from "./internal/error";
-export { InvalidSignatureError } from "./internal/signature";
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
 export {
   SystemsManagerClient,
   SystemsManagerParameter,
   SystemsManagerServiceError,
-} from "./internal/ssm";
+} from "./internal/ssm.ts";


### PR DESCRIPTION
This pull request introduces several changes to improve compatibility with Deno, enhance type safety, and modernize the codebase. The most significant updates include replacing Node.js-specific functionality with Deno-compatible APIs, adding `.ts` extensions to internal imports for Deno compatibility, and using modern TypeScript features like `override` and `type` imports for better clarity and maintainability.

### Compatibility with Deno:
* Replaced `process.env.NODE_ENV` with `Deno.env.get('NODE_ENV')` in `build.mjs` to make environment variable access compatible with Deno.
* Updated `process.exit()` to `Deno.exit()` in `build.mjs` and added error handling with `try/catch` for build failures.

### TypeScript modernization:
* Added the `override` modifier to `handleError` methods in various AWS service clients to explicitly indicate method overrides. [[1]](diffhunk://#diff-e6c9df51d4129042c096d6478411b5a5f46dde1115523100e7702593514af500L75-R75) [[2]](diffhunk://#diff-66dddbee2faaa0733d5061eac9917958b5390e4c0d0fdb7294cfddbad9c09472L82-R82) [[3]](diffhunk://#diff-a0b0d1740a6553c2ab10f3e362a561699db0f1a4868b5179dce99ea577f5cf47L298-R298) [[4]](diffhunk://#diff-01ad5b3090f447b93dbb4e0efd7c976ab2a58bda2d854aed285b5cd3c2034ca0L134-R134) [[5]](diffhunk://#diff-ecee0b5f11fae3a4641dc9c0207ed6419f058ec42be053d60efad63aa24681b2L110-R110) [[6]](diffhunk://#diff-99d7bf779c37675b769ac9e0651585c0f380a4d52e9c575256af3609f77d0e5cL574-R574) [[7]](diffhunk://#diff-51d7daf57be84bb865fef9c6ba2968223733498fe374473e0e05a8eb96f18437L328-R329) [[8]](diffhunk://#diff-65525413f88f90fc68d1eeacecdd01a8d5d682a45496814916b1b680b4a2fd7dL87-R87)
* Used `type` imports for improved clarity in files like `src/internal/client.ts` and `src/internal/event-bridge.ts`. [[1]](diffhunk://#diff-acef33342882c2f528130d9ff0dd74013a342f9d7c4ef8415640c3f43a779077L1-R5) [[2]](diffhunk://#diff-66dddbee2faaa0733d5061eac9917958b5390e4c0d0fdb7294cfddbad9c09472L1-R9)

### Deno compatibility for imports:
* Added `.ts` extensions to all internal imports across multiple files to comply with Deno’s import resolution requirements. [[1]](diffhunk://#diff-1e7b175795da30ac11ba60f6ba0aba3a1a9e6d15711de68fdbdcddbf4aa31773L1-R1) [[2]](diffhunk://#diff-1e7b175795da30ac11ba60f6ba0aba3a1a9e6d15711de68fdbdcddbf4aa31773L10-R15) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L10-R34) [[4]](diffhunk://#diff-acef33342882c2f528130d9ff0dd74013a342f9d7c4ef8415640c3f43a779077L1-R5) [[5]](diffhunk://#diff-1efe38be0ed095b15c7a06573eef319a4485140095bfd54d951c28eb5b46f187L1-R2) [[6]](diffhunk://#diff-e6c9df51d4129042c096d6478411b5a5f46dde1115523100e7702593514af500L1-R1) [[7]](diffhunk://#diff-66dddbee2faaa0733d5061eac9917958b5390e4c0d0fdb7294cfddbad9c09472L1-R9) [[8]](diffhunk://#diff-a0b0d1740a6553c2ab10f3e362a561699db0f1a4868b5179dce99ea577f5cf47L3-R10) [[9]](diffhunk://#diff-01ad5b3090f447b93dbb4e0efd7c976ab2a58bda2d854aed285b5cd3c2034ca0L4-R9) [[10]](diffhunk://#diff-ecee0b5f11fae3a4641dc9c0207ed6419f058ec42be053d60efad63aa24681b2L4-R9) [[11]](diffhunk://#diff-99d7bf779c37675b769ac9e0651585c0f380a4d52e9c575256af3609f77d0e5cL4-R8) [[12]](diffhunk://#diff-1f1ee713779595cfe0a900168b1db15182f1bc885fe9f9850f31168f8bb0d8f8L3-R9) [[13]](diffhunk://#diff-03fbd3803705ec566e6a805abe90ff0f2ede38e2f040f05357cc96e2d7165008L4-R13) [[14]](diffhunk://#diff-51d7daf57be84bb865fef9c6ba2968223733498fe374473e0e05a8eb96f18437L1-R9) [[15]](diffhunk://#diff-65525413f88f90fc68d1eeacecdd01a8d5d682a45496814916b1b680b4a2fd7dL4-R9) [[16]](diffhunk://#diff-5e950ce09a85a502644e23061f3cc7e0db6111cd60f2ff7ee0266837ed70670fL1-R1)

### Dependency updates:
* Updated the `k6` dependency in `deno.json` to use the `@types/k6` package for improved type definitions.

### Other improvements:
* Replaced the deprecated `uuidv4` utility with `crypto.randomUUID()` for generating UUIDs in `SecretsManagerClient`. [[1]](diffhunk://#diff-1f1ee713779595cfe0a900168b1db15182f1bc885fe9f9850f31168f8bb0d8f8L148-R147) [[2]](diffhunk://#diff-1f1ee713779595cfe0a900168b1db15182f1bc885fe9f9850f31168f8bb0d8f8L204-R203) 

These changes collectively enhance the compatibility, maintainability, and clarity of the codebase, particularly for environments using Deno.This pull request introduces several updates, primarily focusing on the migration to Deno, improved error handling, and code modernization. Key changes include replacing Node.js-specific functionality with Deno APIs, adding `.ts` extensions to module imports for compatibility, and modernizing the codebase with TypeScript features like `override` and `type` annotations.

### Migration to Deno:
* Replaced `process.env` with `Deno.env.get` for environment variable access in `build.mjs`.
* Replaced `process.exit` with `Deno.exit` for process termination in `build.mjs`.

### Module Import Updates:
* Added `.ts` extensions to all internal module imports across multiple files for Deno compatibility. Examples include `src/event-bridge.ts`, `src/internal/client.ts`, and others. [[1]](diffhunk://#diff-1e7b175795da30ac11ba60f6ba0aba3a1a9e6d15711de68fdbdcddbf4aa31773L1-R1) [[2]](diffhunk://#diff-acef33342882c2f528130d9ff0dd74013a342f9d7c4ef8415640c3f43a779077L1-R5) [[3]](diffhunk://#diff-66dddbee2faaa0733d5061eac9917958b5390e4c0d0fdb7294cfddbad9c09472L1-R9)

### Improved Error Handling:
* Added the `override` keyword to `handleError` method overrides in various AWS client classes (e.g., `S3Client`, `KinesisClient`, `SecretsManagerClient`) to ensure clarity and adherence to TypeScript best practices. [[1]](diffhunk://#diff-99d7bf779c37675b769ac9e0651585c0f380a4d52e9c575256af3609f77d0e5cL574-R574) [[2]](diffhunk://#diff-a0b0d1740a6553c2ab10f3e362a561699db0f1a4868b5179dce99ea577f5cf47L298-R298) [[3]](diffhunk://#diff-1f1ee713779595cfe0a900168b1db15182f1bc885fe9f9850f31168f8bb0d8f8L294-R293)

### Code Modernization:
* Replaced `uuidv4` with `crypto.randomUUID` in `SecretsManagerClient` for generating unique identifiers, aligning with modern web standards. [[1]](diffhunk://#diff-1f1ee713779595cfe0a900168b1db15182f1bc885fe9f9850f31168f8bb0d8f8L148-R147) [[2]](diffhunk://#diff-1f1ee713779595cfe0a900168b1db15182f1bc885fe9f9850f31168f8bb0d8f8L204-R203)
* Introduced `type` annotations for imports (e.g., `type RefinedResponse`) to improve type clarity in files like `src/internal/client.ts` and `src/internal/event-bridge.ts`. [[1]](diffhunk://#diff-acef33342882c2f528130d9ff0dd74013a342f9d7c4ef8415640c3f43a779077L1-R5) [[2]](diffhunk://#diff-66dddbee2faaa0733d5061eac9917958b5390e4c0d0fdb7294cfddbad9c09472L1-R9)

### Dependency Updates:
* Fixed an incorrect dependency in `deno.json` by replacing `"k6": "npm:k6@^0.0.0"` with `"k6": "npm:@types/k6@^1.0.2"`.