### PR TITLE
fix: fix 'occured' -> 'occurred' in error messages across 5 AWS service modules

### DIFF
--- a/src/internal/event-bridge.ts
+++ b/src/internal/event-bridge.ts
@@ -111,7 +111,7 @@ export class EventBridgeClient extends AWSClient {
 
     if (errorCode === 1500) {
       throw new EventBridgeServiceError(
-        "An error occured on the server side",
+        "An error occurred on the server side",
         "InternalServiceError",
         operation as EventBridgeOperation,
       );

--- a/src/internal/kinesis.ts
+++ b/src/internal/kinesis.ts
@@ -327,7 +327,7 @@ export class KinesisClient extends AWSClient {
 
     if (errorCode === 1500) {
       throw new KinesisServiceError(
-        "An error occured on the server side",
+        "An error occurred on the server side",
         "InternalServiceError",
         operation || "Unknown",
       );

--- a/src/internal/kms.ts
+++ b/src/internal/kms.ts
@@ -163,7 +163,7 @@ export class KMSClient extends AWSClient {
 
     if (errorCode === 1500) {
       throw new KMSServiceError(
-        "An error occured on the server side",
+        "An error occurred on the server side",
         "InternalServiceError",
         operation as KMSOperation,
       );

--- a/src/internal/secrets-manager.ts
+++ b/src/internal/secrets-manager.ts
@@ -322,7 +322,7 @@ export class SecretsManagerClient extends AWSClient {
 
     if (errorCode === 1500) {
       throw new SecretsManagerServiceError(
-        "An error occured on the server side",
+        "An error occurred on the server side",
         "InternalServiceError",
         operation as SecretsManagerOperation,
       );

--- a/src/internal/ssm.ts
+++ b/src/internal/ssm.ts
@@ -116,7 +116,7 @@ export class SystemsManagerClient extends AWSClient {
 
     if (errorCode === 1500) {
       throw new SystemsManagerServiceError(
-        "An error occured on the server side",
+        "An error occurred on the server side",
         "InternalServiceError",
         operation as SystemsManagerOperation,
       );


### PR DESCRIPTION
Five AWS service modules contained the same error message typo `An error occured on the server side`:

| File | Line |
|------|------|
| `src/internal/kms.ts` | 166 |
| `src/internal/ssm.ts` | 119 |
| `src/internal/event-bridge.ts` | 114 |
| `src/internal/kinesis.ts` | 330 |
| `src/internal/secrets-manager.ts` | 325 |

Fixed to `occurred`. These are user-visible error messages thrown when AWS services return server-side errors. String-literal-only change.