### PR TITLE
Add AWS DynamoDB support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # k6-jslib-aws
 
-TypeScript library that lets k6 load test scripts interact with AWS services (S3, SQS, KMS, Lambda, Kinesis, EventBridge, SecretsManager, SSM). Distributed as bundled ESM via the k6 jslib CDN.
+TypeScript library that lets k6 load test scripts interact with AWS services (S3, SQS, KMS, Lambda, Kinesis, EventBridge, SecretsManager, SSM, DynamoDB). Distributed as bundled ESM via the k6 jslib CDN.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Extensive documentation and examples for each of these clients can be found in t
 
 ## Supported services and features
 
+-   [`DynamoDB`](./examples/dynamo-db.js): allows to put, get, delete, update, query and scan items in AWS DynamoDB.
 -   [`EventBridge`](https://grafana.com/docs/k6/latest/javascript-api/jslib/aws/eventbridgeclient/): allows to put events to AWS EventBridge.
 -   [`Kinesis`](./examples/kinesis.js): allows to list streams, create streams, put records, list shards, get shard iterators, and get records from AWS Kinesis.
 -   [`KMS`](https://grafana.com/docs/k6/latest/javascript-api/jslib/aws/kmsclient/): allows to list KMS keys and generate a unique symmetric data key for use outside of AWS KMS

--- a/build.mjs
+++ b/build.mjs
@@ -10,6 +10,7 @@ const buildOptions = {
         { in: 'src/s3.ts', out: 's3' },
         { in: 'src/secrets-manager.ts', out: 'secrets-manager' },
         { in: 'src/sqs.ts', out: 'sqs' },
+        { in: 'src/dynamo-db.ts', out: 'dynamo-db' },
         { in: 'src/ssm.ts', out: 'ssm' },
         { in: 'src/kms.ts', out: 'kms' },
         { in: 'src/kinesis.ts', out: 'kinesis' },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             - '127.0.0.1:4566:4566' # LocalStack Gateway
             - '127.0.0.1:4510-4559:4510-4559' # external services port range
         environment:
-            - SERVICES=s3,secretsmanager,sqs,kms,ssm,kinesis,lambda
+            - SERVICES=s3,secretsmanager,sqs,kms,ssm,kinesis,lambda,dynamodb
             - S3_SKIP_SIGNATURE_VALIDATION=0 # enable signature validation
             - DEBUG=${DEBUG-}
             - PERSISTENCE=${PERSISTENCE-}

--- a/examples/dynamo-db.js
+++ b/examples/dynamo-db.js
@@ -13,9 +13,13 @@ const awsConfig = new AWSConfig({
 const dynamoDb = new DynamoDBClient(awsConfig);
 const testTableName = "test-jslib-aws-table";
 
+// Distinct from any partition key used by seeded test data, so this demo
+// never collides with pre-existing items for low VU ids.
+const examplePartitionKey = "tenant#example";
+
 export default async function () {
   const key = {
-    pk: { S: "tenant#1" },
+    pk: { S: examplePartitionKey },
     sk: { S: `item#${exec.vu.idInTest}` },
   };
 
@@ -47,26 +51,28 @@ export default async function () {
   check(updated, { "item was updated": (i) => i.value.S === "updated by k6" });
 
   // Query for this tenant's items, filtering down to the value we just set
-  // (other VUs are writing under the same partition key concurrently).
+  // (other VUs are writing under the same partition key concurrently). A
+  // consistent read avoids racing the update above.
   const matches = await dynamoDb.query(testTableName, "pk = :pk", {
     expressionAttributeNames: { "#v": "value" },
     expressionAttributeValues: {
-      ":pk": { S: "tenant#1" },
+      ":pk": { S: examplePartitionKey },
       ":v": { S: "updated by k6" },
     },
     filterExpression: "#v = :v",
+    consistentRead: true,
   });
   check(matches, { "query found the item": (r) => r.count >= 1 });
 
   // Scan the whole table, one page at a time.
   let page = await dynamoDb.scan(testTableName, { limit: 25 });
-  let scannedCount = page.count;
+  let scannedCount = page.scannedCount;
   while (page.lastEvaluatedKey) {
     page = await dynamoDb.scan(testTableName, {
       limit: 25,
       exclusiveStartKey: page.lastEvaluatedKey,
     });
-    scannedCount += page.count;
+    scannedCount += page.scannedCount;
   }
   check(scannedCount, { "scan visited at least one item": (n) => n >= 1 });
 

--- a/examples/dynamo-db.js
+++ b/examples/dynamo-db.js
@@ -19,31 +19,56 @@ export default async function () {
     sk: { S: `item#${exec.vu.idInTest}` },
   };
 
-  // Create or replace an item.
-  await dynamoDb.putItem(testTableName, {
-    ...key,
-    value: { S: "hello from k6" },
-  });
+  // Create the item, guarding against overwriting one left over from a
+  // previous, uncleaned run of this same VU.
+  await dynamoDb.putItem(
+    testTableName,
+    { ...key, value: { S: "hello from k6" } },
+    { conditionExpression: "attribute_not_exists(pk)" },
+  );
 
-  // Read it back.
-  const item = await dynamoDb.getItem(testTableName, key);
+  // Read it back with a strongly consistent read, since we just wrote it.
+  const item = await dynamoDb.getItem(testTableName, key, {
+    consistentRead: true,
+  });
   check(item, { "item was written": (i) => i?.value?.S === "hello from k6" });
 
-  // Update a single attribute.
-  await dynamoDb.updateItem(
+  // Update a single attribute and get the new value back.
+  const updated = await dynamoDb.updateItem(
     testTableName,
     key,
     "SET #v = :v",
     {
       expressionAttributeNames: { "#v": "value" },
       expressionAttributeValues: { ":v": { S: "updated by k6" } },
+      returnValues: "ALL_NEW",
     },
   );
+  check(updated, { "item was updated": (i) => i.value.S === "updated by k6" });
 
-  // Query all items for this tenant.
-  await dynamoDb.query(testTableName, "pk = :pk", {
-    expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+  // Query for this tenant's items, filtering down to the value we just set
+  // (other VUs are writing under the same partition key concurrently).
+  const matches = await dynamoDb.query(testTableName, "pk = :pk", {
+    expressionAttributeNames: { "#v": "value" },
+    expressionAttributeValues: {
+      ":pk": { S: "tenant#1" },
+      ":v": { S: "updated by k6" },
+    },
+    filterExpression: "#v = :v",
   });
+  check(matches, { "query found the item": (r) => r.count >= 1 });
+
+  // Scan the whole table, one page at a time.
+  let page = await dynamoDb.scan(testTableName, { limit: 25 });
+  let scannedCount = page.count;
+  while (page.lastEvaluatedKey) {
+    page = await dynamoDb.scan(testTableName, {
+      limit: 25,
+      exclusiveStartKey: page.lastEvaluatedKey,
+    });
+    scannedCount += page.count;
+  }
+  check(scannedCount, { "scan visited at least one item": (n) => n >= 1 });
 
   // Clean up.
   await dynamoDb.deleteItem(testTableName, key);

--- a/examples/dynamo-db.js
+++ b/examples/dynamo-db.js
@@ -1,0 +1,50 @@
+import { check } from "k6";
+import exec from "k6/execution";
+
+import { AWSConfig, DynamoDBClient } from "../dist/dynamo-db.js";
+
+const awsConfig = new AWSConfig({
+  region: __ENV.AWS_REGION,
+  accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+  secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+  sessionToken: __ENV.AWS_SESSION_TOKEN,
+});
+
+const dynamoDb = new DynamoDBClient(awsConfig);
+const testTableName = "test-jslib-aws-table";
+
+export default async function () {
+  const key = {
+    pk: { S: "tenant#1" },
+    sk: { S: `item#${exec.vu.idInTest}` },
+  };
+
+  // Create or replace an item.
+  await dynamoDb.putItem(testTableName, {
+    ...key,
+    value: { S: "hello from k6" },
+  });
+
+  // Read it back.
+  const item = await dynamoDb.getItem(testTableName, key);
+  check(item, { "item was written": (i) => i?.value?.S === "hello from k6" });
+
+  // Update a single attribute.
+  await dynamoDb.updateItem(
+    testTableName,
+    key,
+    "SET #v = :v",
+    {
+      expressionAttributeNames: { "#v": "value" },
+      expressionAttributeValues: { ":v": { S: "updated by k6" } },
+    },
+  );
+
+  // Query all items for this tenant.
+  await dynamoDb.query(testTableName, "pk = :pk", {
+    expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+  });
+
+  // Clean up.
+  await dynamoDb.deleteItem(testTableName, key);
+}

--- a/localstack/init/ready.d/dynamo-db.sh
+++ b/localstack/init/ready.d/dynamo-db.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+awslocal dynamodb create-table \
+  --table-name test-jslib-aws-table \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+
+awslocal dynamodb put-item \
+  --table-name test-jslib-aws-table \
+  --item '{"pk": {"S": "tenant#1"}, "sk": {"S": "item#1"}, "value": {"S": "alpha"}}'
+
+awslocal dynamodb put-item \
+  --table-name test-jslib-aws-table \
+  --item '{"pk": {"S": "tenant#1"}, "sk": {"S": "item#2"}, "value": {"S": "beta"}}'
+
+awslocal dynamodb put-item \
+  --table-name test-jslib-aws-table \
+  --item '{"pk": {"S": "tenant#2"}, "sk": {"S": "item#1"}, "value": {"S": "gamma"}}'
+
+awslocal dynamodb put-item \
+  --table-name test-jslib-aws-table \
+  --item '{"pk": {"S": "tenant#1"}, "sk": {"S": "item#update"}, "value": {"S": "original"}}'
+
+awslocal dynamodb put-item \
+  --table-name test-jslib-aws-table \
+  --item '{"pk": {"S": "tenant#1"}, "sk": {"S": "item#delete"}, "value": {"S": "to-delete"}}'

--- a/localstack/init/ready.d/dynamo-db.sh
+++ b/localstack/init/ready.d/dynamo-db.sh
@@ -17,11 +17,3 @@ awslocal dynamodb put-item \
 awslocal dynamodb put-item \
   --table-name test-jslib-aws-table \
   --item '{"pk": {"S": "tenant#2"}, "sk": {"S": "item#1"}, "value": {"S": "gamma"}}'
-
-awslocal dynamodb put-item \
-  --table-name test-jslib-aws-table \
-  --item '{"pk": {"S": "tenant#1"}, "sk": {"S": "item#update"}, "value": {"S": "original"}}'
-
-awslocal dynamodb put-item \
-  --table-name test-jslib-aws-table \
-  --item '{"pk": {"S": "tenant#1"}, "sk": {"S": "item#delete"}, "value": {"S": "to-delete"}}'

--- a/src/dynamo-db.ts
+++ b/src/dynamo-db.ts
@@ -1,0 +1,17 @@
+// Re-Export public symbols
+export { AWSConfig, InvalidAWSConfigError } from "./internal/config.ts";
+export {
+  AWSError,
+  DNSError,
+  GeneralError,
+  HTTP2Error,
+  NetworkError,
+  TCPError,
+  TLSError,
+} from "./internal/error.ts";
+export { InvalidSignatureError } from "./internal/signature.ts";
+export {
+  DynamoDBClient,
+  DynamoDBServiceError,
+  QueryResponse,
+} from "./internal/dynamo-db.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,11 @@ export {
   SystemsManagerServiceError,
 } from "./internal/ssm.ts";
 export { ReceivedMessage, SQSClient } from "./sqs.ts";
+export {
+  DynamoDBClient,
+  DynamoDBServiceError,
+  QueryResponse,
+} from "./internal/dynamo-db.ts";
 export { KinesisClient } from "./internal/kinesis.ts";
 export { EventBridgeClient } from "./internal/event-bridge.ts";
 export { LambdaClient, LambdaInvocationError } from "./lambda.ts";

--- a/src/internal/dynamo-db.ts
+++ b/src/internal/dynamo-db.ts
@@ -59,24 +59,7 @@ export class DynamoDBClient extends AWSClient {
   ): Promise<AttributeMap | undefined> {
     let body: Record<string, unknown> = { TableName: tableName, Item: item };
 
-    if (typeof options.conditionExpression !== "undefined") {
-      body = { ...body, ConditionExpression: options.conditionExpression };
-    }
-    if (typeof options.expressionAttributeNames !== "undefined") {
-      body = {
-        ...body,
-        ExpressionAttributeNames: options.expressionAttributeNames,
-      };
-    }
-    if (typeof options.expressionAttributeValues !== "undefined") {
-      body = {
-        ...body,
-        ExpressionAttributeValues: options.expressionAttributeValues,
-      };
-    }
-    if (typeof options.returnValues !== "undefined") {
-      body = { ...body, ReturnValues: options.returnValues };
-    }
+    body = this._withConditionalWriteOptions(body, options);
 
     const res = await this._sendRequest("PutItem", body);
 
@@ -135,24 +118,7 @@ export class DynamoDBClient extends AWSClient {
   ): Promise<AttributeMap | undefined> {
     let body: Record<string, unknown> = { TableName: tableName, Key: key };
 
-    if (typeof options.conditionExpression !== "undefined") {
-      body = { ...body, ConditionExpression: options.conditionExpression };
-    }
-    if (typeof options.expressionAttributeNames !== "undefined") {
-      body = {
-        ...body,
-        ExpressionAttributeNames: options.expressionAttributeNames,
-      };
-    }
-    if (typeof options.expressionAttributeValues !== "undefined") {
-      body = {
-        ...body,
-        ExpressionAttributeValues: options.expressionAttributeValues,
-      };
-    }
-    if (typeof options.returnValues !== "undefined") {
-      body = { ...body, ReturnValues: options.returnValues };
-    }
+    body = this._withConditionalWriteOptions(body, options);
 
     const res = await this._sendRequest("DeleteItem", body);
 
@@ -182,24 +148,7 @@ export class DynamoDBClient extends AWSClient {
       UpdateExpression: updateExpression,
     };
 
-    if (typeof options.conditionExpression !== "undefined") {
-      body = { ...body, ConditionExpression: options.conditionExpression };
-    }
-    if (typeof options.expressionAttributeNames !== "undefined") {
-      body = {
-        ...body,
-        ExpressionAttributeNames: options.expressionAttributeNames,
-      };
-    }
-    if (typeof options.expressionAttributeValues !== "undefined") {
-      body = {
-        ...body,
-        ExpressionAttributeValues: options.expressionAttributeValues,
-      };
-    }
-    if (typeof options.returnValues !== "undefined") {
-      body = { ...body, ReturnValues: options.returnValues };
-    }
+    body = this._withConditionalWriteOptions(body, options);
 
     const res = await this._sendRequest("UpdateItem", body);
 
@@ -254,6 +203,37 @@ export class DynamoDBClient extends AWSClient {
 
     const res = await this._sendRequest("Scan", body);
     return QueryResponse.fromJSON(res.json() as JSONObject);
+  }
+
+  private _withConditionalWriteOptions(
+    body: Record<string, unknown>,
+    options: {
+      conditionExpression?: string;
+      expressionAttributeNames?: Record<string, string>;
+      expressionAttributeValues?: AttributeMap;
+      returnValues?: ReturnValues;
+    },
+  ): Record<string, unknown> {
+    if (typeof options.conditionExpression !== "undefined") {
+      body = { ...body, ConditionExpression: options.conditionExpression };
+    }
+    if (typeof options.expressionAttributeNames !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeNames: options.expressionAttributeNames,
+      };
+    }
+    if (typeof options.expressionAttributeValues !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeValues: options.expressionAttributeValues,
+      };
+    }
+    if (typeof options.returnValues !== "undefined") {
+      body = { ...body, ReturnValues: options.returnValues };
+    }
+
+    return body;
   }
 
   private _withCommonQueryLikeOptions(
@@ -388,7 +368,7 @@ export interface AttributeValue {
 export type AttributeMap = Record<string, AttributeValue>;
 
 /**
- * Determines which item attributes a write operation should return.
+ * Determines which item attributes UpdateItem should return.
  */
 export type ReturnValues =
   | "NONE"
@@ -396,6 +376,13 @@ export type ReturnValues =
   | "UPDATED_OLD"
   | "ALL_NEW"
   | "UPDATED_NEW";
+
+/**
+ * Determines which item attributes PutItem/DeleteItem should return.
+ * Unlike UpdateItem, they only support returning the item's previous
+ * attributes, or nothing.
+ */
+export type WriteReturnValues = "NONE" | "ALL_OLD";
 
 export interface PutItemOptions {
   /**
@@ -413,7 +400,7 @@ export interface PutItemOptions {
   /**
    * Whether to return the item's previous attributes ("ALL_OLD") or nothing ("NONE", the default).
    */
-  returnValues?: ReturnValues;
+  returnValues?: WriteReturnValues;
 }
 
 export interface GetItemOptions {
@@ -447,7 +434,7 @@ export interface DeleteItemOptions {
   /**
    * Whether to return the item's attributes as they were before deletion ("ALL_OLD") or nothing ("NONE", the default).
    */
-  returnValues?: ReturnValues;
+  returnValues?: WriteReturnValues;
 }
 
 export interface UpdateItemOptions {

--- a/src/internal/dynamo-db.ts
+++ b/src/internal/dynamo-db.ts
@@ -1,0 +1,602 @@
+import http, { RefinedResponse, ResponseType } from "k6/http";
+
+import { AWSClient } from "./client.ts";
+import { AWSConfig } from "./config.ts";
+import { InvalidSignatureError, SignatureV4 } from "./signature.ts";
+import { HTTPHeaders } from "./http.ts";
+import { AWSError } from "./error.ts";
+import { AMZ_TARGET_HEADER } from "./constants.ts";
+import { JSONObject } from "./json.ts";
+
+/**
+ * Class allowing to interact with Amazon AWS's DynamoDB service.
+ *
+ * Table lifecycle (creation, deletion, etc.) is intentionally not covered:
+ * this client only exposes the item-level operations a k6 load test would
+ * exercise at runtime. Tables are expected to already exist.
+ */
+export class DynamoDBClient extends AWSClient {
+  private readonly signature: SignatureV4;
+  private readonly commonHeaders: HTTPHeaders;
+
+  private readonly serviceVersion: string;
+
+  constructor(awsConfig: AWSConfig) {
+    super(awsConfig, "dynamodb");
+
+    this.serviceVersion = "DynamoDB_20120810";
+
+    this.signature = new SignatureV4({
+      service: this.serviceName,
+      region: this.awsConfig.region,
+      credentials: {
+        accessKeyId: this.awsConfig.accessKeyId,
+        secretAccessKey: this.awsConfig.secretAccessKey,
+        sessionToken: this.awsConfig.sessionToken,
+      },
+      uriEscapePath: true,
+      applyChecksum: true,
+    });
+
+    this.commonHeaders = {
+      "Content-Type": "application/x-amz-json-1.0",
+    };
+  }
+
+  /**
+   * Creates a new item, or replaces an existing item with the same primary key.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html
+   * @param {string} tableName - The name of the table to put the item into.
+   * @param {AttributeMap} item - The item to put, described using DynamoDB's typed AttributeValue map.
+   * @param {PutItemOptions} [options={}] - Options for the request.
+   * @returns {AttributeMap | undefined} - The item's previous attributes, if `options.returnValues` was set to `"ALL_OLD"`.
+   */
+  async putItem(
+    tableName: string,
+    item: AttributeMap,
+    options: PutItemOptions = {},
+  ): Promise<AttributeMap | undefined> {
+    let body: Record<string, unknown> = { TableName: tableName, Item: item };
+
+    if (typeof options.conditionExpression !== "undefined") {
+      body = { ...body, ConditionExpression: options.conditionExpression };
+    }
+    if (typeof options.expressionAttributeNames !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeNames: options.expressionAttributeNames,
+      };
+    }
+    if (typeof options.expressionAttributeValues !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeValues: options.expressionAttributeValues,
+      };
+    }
+    if (typeof options.returnValues !== "undefined") {
+      body = { ...body, ReturnValues: options.returnValues };
+    }
+
+    const res = await this._sendRequest("PutItem", body);
+
+    const parsed = res.json() as JSONObject;
+    return parsed["Attributes"] as unknown as AttributeMap | undefined;
+  }
+
+  /**
+   * Retrieves a single item from a table by its primary key.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html
+   * @param {string} tableName - The name of the table to read from.
+   * @param {AttributeMap} key - The primary key of the item to retrieve.
+   * @param {GetItemOptions} [options={}] - Options for the request.
+   * @returns {AttributeMap | undefined} - The requested item, or `undefined` if it does not exist.
+   */
+  async getItem(
+    tableName: string,
+    key: AttributeMap,
+    options: GetItemOptions = {},
+  ): Promise<AttributeMap | undefined> {
+    let body: Record<string, unknown> = { TableName: tableName, Key: key };
+
+    if (typeof options.consistentRead !== "undefined") {
+      body = { ...body, ConsistentRead: options.consistentRead };
+    }
+    if (typeof options.projectionExpression !== "undefined") {
+      body = { ...body, ProjectionExpression: options.projectionExpression };
+    }
+    if (typeof options.expressionAttributeNames !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeNames: options.expressionAttributeNames,
+      };
+    }
+
+    const res = await this._sendRequest("GetItem", body);
+
+    const parsed = res.json() as JSONObject;
+    return parsed["Item"] as unknown as AttributeMap | undefined;
+  }
+
+  /**
+   * Deletes a single item from a table by its primary key.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html
+   * @param {string} tableName - The name of the table to delete from.
+   * @param {AttributeMap} key - The primary key of the item to delete.
+   * @param {DeleteItemOptions} [options={}] - Options for the request.
+   * @returns {AttributeMap | undefined} - The item's attributes as they were before deletion, if `options.returnValues` was set to `"ALL_OLD"`.
+   */
+  async deleteItem(
+    tableName: string,
+    key: AttributeMap,
+    options: DeleteItemOptions = {},
+  ): Promise<AttributeMap | undefined> {
+    let body: Record<string, unknown> = { TableName: tableName, Key: key };
+
+    if (typeof options.conditionExpression !== "undefined") {
+      body = { ...body, ConditionExpression: options.conditionExpression };
+    }
+    if (typeof options.expressionAttributeNames !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeNames: options.expressionAttributeNames,
+      };
+    }
+    if (typeof options.expressionAttributeValues !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeValues: options.expressionAttributeValues,
+      };
+    }
+    if (typeof options.returnValues !== "undefined") {
+      body = { ...body, ReturnValues: options.returnValues };
+    }
+
+    const res = await this._sendRequest("DeleteItem", body);
+
+    const parsed = res.json() as JSONObject;
+    return parsed["Attributes"] as unknown as AttributeMap | undefined;
+  }
+
+  /**
+   * Edits an existing item's attributes, or creates a new item if it does not already exist.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html
+   * @param {string} tableName - The name of the table containing the item to update.
+   * @param {AttributeMap} key - The primary key of the item to update.
+   * @param {string} updateExpression - An expression that defines one or more attributes to be updated.
+   * @param {UpdateItemOptions} [options={}] - Options for the request.
+   * @returns {AttributeMap | undefined} - The item's attributes, in the form specified by `options.returnValues`.
+   */
+  async updateItem(
+    tableName: string,
+    key: AttributeMap,
+    updateExpression: string,
+    options: UpdateItemOptions = {},
+  ): Promise<AttributeMap | undefined> {
+    let body: Record<string, unknown> = {
+      TableName: tableName,
+      Key: key,
+      UpdateExpression: updateExpression,
+    };
+
+    if (typeof options.conditionExpression !== "undefined") {
+      body = { ...body, ConditionExpression: options.conditionExpression };
+    }
+    if (typeof options.expressionAttributeNames !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeNames: options.expressionAttributeNames,
+      };
+    }
+    if (typeof options.expressionAttributeValues !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeValues: options.expressionAttributeValues,
+      };
+    }
+    if (typeof options.returnValues !== "undefined") {
+      body = { ...body, ReturnValues: options.returnValues };
+    }
+
+    const res = await this._sendRequest("UpdateItem", body);
+
+    const parsed = res.json() as JSONObject;
+    return parsed["Attributes"] as unknown as AttributeMap | undefined;
+  }
+
+  /**
+   * Finds items in a table or a secondary index using the partition key and, optionally, the sort key.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html
+   * @param {string} tableName - The name of the table to query.
+   * @param {string} keyConditionExpression - The condition that specifies the key values for items to be retrieved.
+   * @param {QueryOptions} [options={}] - Options for the request.
+   * @returns {QueryResponse} - The matched items and pagination information.
+   */
+  async query(
+    tableName: string,
+    keyConditionExpression: string,
+    options: QueryOptions = {},
+  ): Promise<QueryResponse> {
+    let body: Record<string, unknown> = {
+      TableName: tableName,
+      KeyConditionExpression: keyConditionExpression,
+    };
+
+    body = this._withCommonQueryLikeOptions(body, options);
+
+    if (typeof options.scanIndexForward !== "undefined") {
+      body = { ...body, ScanIndexForward: options.scanIndexForward };
+    }
+
+    const res = await this._sendRequest("Query", body);
+    return QueryResponse.fromJSON(res.json() as JSONObject);
+  }
+
+  /**
+   * Returns one or more items and item attributes by accessing every item in a table or a secondary index.
+   *
+   * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
+   * @param {string} tableName - The name of the table to scan.
+   * @param {ScanOptions} [options={}] - Options for the request.
+   * @returns {QueryResponse} - The matched items and pagination information.
+   */
+  async scan(
+    tableName: string,
+    options: ScanOptions = {},
+  ): Promise<QueryResponse> {
+    let body: Record<string, unknown> = { TableName: tableName };
+
+    body = this._withCommonQueryLikeOptions(body, options);
+
+    const res = await this._sendRequest("Scan", body);
+    return QueryResponse.fromJSON(res.json() as JSONObject);
+  }
+
+  private _withCommonQueryLikeOptions(
+    body: Record<string, unknown>,
+    options: QueryOptions | ScanOptions,
+  ): Record<string, unknown> {
+    if (typeof options.expressionAttributeNames !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeNames: options.expressionAttributeNames,
+      };
+    }
+    if (typeof options.expressionAttributeValues !== "undefined") {
+      body = {
+        ...body,
+        ExpressionAttributeValues: options.expressionAttributeValues,
+      };
+    }
+    if (typeof options.filterExpression !== "undefined") {
+      body = { ...body, FilterExpression: options.filterExpression };
+    }
+    if (typeof options.indexName !== "undefined") {
+      body = { ...body, IndexName: options.indexName };
+    }
+    if (typeof options.limit !== "undefined") {
+      body = { ...body, Limit: options.limit };
+    }
+    if (typeof options.exclusiveStartKey !== "undefined") {
+      body = { ...body, ExclusiveStartKey: options.exclusiveStartKey };
+    }
+
+    return body;
+  }
+
+  private async _sendRequest(
+    action: DynamoDBOperation,
+    body: Record<string, unknown>,
+  ): Promise<RefinedResponse<ResponseType>> {
+    const signedRequest = this.signature.sign(
+      {
+        method: "POST",
+        endpoint: this.endpoint,
+        path: "/",
+        headers: {
+          ...this.commonHeaders,
+          [AMZ_TARGET_HEADER]: `${this.serviceVersion}.${action}`,
+        },
+        body: JSON.stringify(body),
+      },
+      {},
+    );
+
+    const res = await http.asyncRequest(
+      "POST",
+      signedRequest.url,
+      signedRequest.body,
+      {
+        ...this.baseRequestParams,
+        headers: signedRequest.headers,
+      },
+    );
+
+    this.handleError(res, action);
+    return res;
+  }
+
+  protected override handleError(
+    response: RefinedResponse<ResponseType | undefined>,
+    operation?: string,
+  ): boolean {
+    const errored = super.handleError(response, operation);
+    if (!errored) {
+      return false;
+    }
+
+    const errorCode: number = response.error_code;
+    const error = response.json() as JSONObject;
+
+    if (errorCode >= 1400 && errorCode <= 1499) {
+      // In the event of certain errors, the message is not set.
+      // Also, note the inconsistency in casing...
+      const errorMessage: string = (error.Message as string) ||
+        (error.message as string) || (error.__type as string);
+
+      // Handle specifically the case of an invalid signature
+      if (error.__type === "InvalidSignatureException") {
+        throw new InvalidSignatureError(errorMessage, error.__type);
+      }
+
+      // Otherwise throw a standard service error
+      throw new DynamoDBServiceError(
+        errorMessage,
+        error.__type as string,
+        operation as DynamoDBOperation,
+      );
+    }
+
+    if (errorCode === 1500) {
+      throw new DynamoDBServiceError(
+        "An error occurred on the server side",
+        "InternalServiceError",
+        operation as DynamoDBOperation,
+      );
+    }
+
+    return true;
+  }
+}
+
+/**
+ * A DynamoDB typed attribute value.
+ *
+ * Exactly one of these fields should be set, matching the AttributeValue
+ * shape used by AWS's low-level DynamoDB API (e.g. `{ S: "foo" }`, `{ N: "1" }`).
+ */
+export interface AttributeValue {
+  S?: string;
+  N?: string;
+  B?: string;
+  SS?: string[];
+  NS?: string[];
+  BS?: string[];
+  M?: AttributeMap;
+  L?: AttributeValue[];
+  NULL?: boolean;
+  BOOL?: boolean;
+}
+
+/**
+ * A DynamoDB item, or a primary key: a map of attribute names to typed {@link AttributeValue}s.
+ */
+export type AttributeMap = Record<string, AttributeValue>;
+
+/**
+ * Determines which item attributes a write operation should return.
+ */
+export type ReturnValues =
+  | "NONE"
+  | "ALL_OLD"
+  | "UPDATED_OLD"
+  | "ALL_NEW"
+  | "UPDATED_NEW";
+
+export interface PutItemOptions {
+  /**
+   * A condition that must be satisfied for the PutItem operation to succeed.
+   */
+  conditionExpression?: string;
+  /**
+   * Substitution tokens for attribute names in an expression.
+   */
+  expressionAttributeNames?: Record<string, string>;
+  /**
+   * Substitution tokens for attribute values in an expression.
+   */
+  expressionAttributeValues?: AttributeMap;
+  /**
+   * Whether to return the item's previous attributes ("ALL_OLD") or nothing ("NONE", the default).
+   */
+  returnValues?: ReturnValues;
+}
+
+export interface GetItemOptions {
+  /**
+   * Whether to use strongly consistent reads instead of eventually consistent reads.
+   */
+  consistentRead?: boolean;
+  /**
+   * A string that identifies one or more attributes to retrieve from the table.
+   */
+  projectionExpression?: string;
+  /**
+   * Substitution tokens for attribute names in `projectionExpression`.
+   */
+  expressionAttributeNames?: Record<string, string>;
+}
+
+export interface DeleteItemOptions {
+  /**
+   * A condition that must be satisfied for the DeleteItem operation to succeed.
+   */
+  conditionExpression?: string;
+  /**
+   * Substitution tokens for attribute names in an expression.
+   */
+  expressionAttributeNames?: Record<string, string>;
+  /**
+   * Substitution tokens for attribute values in an expression.
+   */
+  expressionAttributeValues?: AttributeMap;
+  /**
+   * Whether to return the item's attributes as they were before deletion ("ALL_OLD") or nothing ("NONE", the default).
+   */
+  returnValues?: ReturnValues;
+}
+
+export interface UpdateItemOptions {
+  /**
+   * A condition that must be satisfied for the UpdateItem operation to succeed.
+   */
+  conditionExpression?: string;
+  /**
+   * Substitution tokens for attribute names in an expression.
+   */
+  expressionAttributeNames?: Record<string, string>;
+  /**
+   * Substitution tokens for attribute values in an expression.
+   */
+  expressionAttributeValues?: AttributeMap;
+  /**
+   * Which item attributes to return, in the form of a {@link ReturnValues}.
+   */
+  returnValues?: ReturnValues;
+}
+
+export interface QueryOptions {
+  /**
+   * Substitution tokens for attribute names in an expression.
+   */
+  expressionAttributeNames?: Record<string, string>;
+  /**
+   * Substitution tokens for attribute values in an expression.
+   */
+  expressionAttributeValues?: AttributeMap;
+  /**
+   * A condition applied after the Query operation, to filter results before they are returned.
+   */
+  filterExpression?: string;
+  /**
+   * The name of a secondary index to query instead of the base table.
+   */
+  indexName?: string;
+  /**
+   * The maximum number of items to evaluate.
+   */
+  limit?: number;
+  /**
+   * Whether to traverse the index in ascending ("true", the default) or descending ("false") order.
+   */
+  scanIndexForward?: boolean;
+  /**
+   * The primary key of the first item that this operation will evaluate, as returned in a previous response's `lastEvaluatedKey`.
+   */
+  exclusiveStartKey?: AttributeMap;
+}
+
+export interface ScanOptions {
+  /**
+   * Substitution tokens for attribute names in an expression.
+   */
+  expressionAttributeNames?: Record<string, string>;
+  /**
+   * Substitution tokens for attribute values in an expression.
+   */
+  expressionAttributeValues?: AttributeMap;
+  /**
+   * A condition applied after the Scan operation, to filter results before they are returned.
+   */
+  filterExpression?: string;
+  /**
+   * The name of a secondary index to scan instead of the base table.
+   */
+  indexName?: string;
+  /**
+   * The maximum number of items to evaluate.
+   */
+  limit?: number;
+  /**
+   * The primary key of the first item that this operation will evaluate, as returned in a previous response's `lastEvaluatedKey`.
+   */
+  exclusiveStartKey?: AttributeMap;
+}
+
+/**
+ * The response format shared by the Query and Scan operations.
+ */
+export class QueryResponse {
+  /**
+   * The items matching the request.
+   */
+  items: AttributeMap[];
+
+  /**
+   * The number of items in the response.
+   */
+  count: number;
+
+  /**
+   * The number of items evaluated, before any `filterExpression` was applied.
+   */
+  scannedCount: number;
+
+  /**
+   * The primary key of the item where the operation stopped. Pass this value
+   * as `exclusiveStartKey` in a subsequent request to continue the operation.
+   * Absent once the operation has processed the last item.
+   */
+  lastEvaluatedKey?: AttributeMap;
+
+  constructor(
+    items: AttributeMap[],
+    count: number,
+    scannedCount: number,
+    lastEvaluatedKey?: AttributeMap,
+  ) {
+    this.items = items;
+    this.count = count;
+    this.scannedCount = scannedCount;
+    this.lastEvaluatedKey = lastEvaluatedKey;
+  }
+
+  static fromJSON(json: JSONObject): QueryResponse {
+    const { Items = [], Count = 0, ScannedCount = 0, LastEvaluatedKey } = json;
+
+    return new QueryResponse(
+      Items as unknown as AttributeMap[],
+      Count as number,
+      ScannedCount as number,
+      LastEvaluatedKey as unknown as AttributeMap | undefined,
+    );
+  }
+}
+
+/**
+ * DynamoDBServiceError indicates an error occurred while interacting with the DynamoDB API.
+ */
+export class DynamoDBServiceError extends AWSError {
+  operation: DynamoDBOperation;
+
+  constructor(message: string, code: string, operation: DynamoDBOperation) {
+    super(message, code);
+    this.name = "DynamoDBServiceError";
+    this.operation = operation;
+  }
+}
+
+/**
+ * DynamoDBOperation describes possible DynamoDB operations implemented by this client.
+ */
+type DynamoDBOperation =
+  | "PutItem"
+  | "GetItem"
+  | "DeleteItem"
+  | "UpdateItem"
+  | "Query"
+  | "Scan";

--- a/src/internal/dynamo-db.ts
+++ b/src/internal/dynamo-db.ts
@@ -240,6 +240,9 @@ export class DynamoDBClient extends AWSClient {
     body: Record<string, unknown>,
     options: QueryOptions | ScanOptions,
   ): Record<string, unknown> {
+    if (typeof options.consistentRead !== "undefined") {
+      body = { ...body, ConsistentRead: options.consistentRead };
+    }
     if (typeof options.expressionAttributeNames !== "undefined") {
       body = {
         ...body,
@@ -331,7 +334,7 @@ export class DynamoDBClient extends AWSClient {
       );
     }
 
-    if (errorCode === 1500) {
+    if (errorCode >= 1500 && errorCode <= 1599) {
       throw new DynamoDBServiceError(
         "An error occurred on the server side",
         "InternalServiceError",
@@ -352,9 +355,11 @@ export class DynamoDBClient extends AWSClient {
 export interface AttributeValue {
   S?: string;
   N?: string;
+  /** Base64-encoded binary data. */
   B?: string;
   SS?: string[];
   NS?: string[];
+  /** Base64-encoded binary data, one entry per set member. */
   BS?: string[];
   M?: AttributeMap;
   L?: AttributeValue[];
@@ -458,6 +463,12 @@ export interface UpdateItemOptions {
 
 export interface QueryOptions {
   /**
+   * Whether to use strongly consistent reads instead of eventually
+   * consistent reads. Not supported when `indexName` is a global secondary
+   * index.
+   */
+  consistentRead?: boolean;
+  /**
    * Substitution tokens for attribute names in an expression.
    */
   expressionAttributeNames?: Record<string, string>;
@@ -488,6 +499,12 @@ export interface QueryOptions {
 }
 
 export interface ScanOptions {
+  /**
+   * Whether to use strongly consistent reads instead of eventually
+   * consistent reads. Not supported when `indexName` is a global secondary
+   * index.
+   */
+  consistentRead?: boolean;
   /**
    * Substitution tokens for attribute names in an expression.
    */

--- a/tests/index.js
+++ b/tests/index.js
@@ -11,6 +11,7 @@ import { signatureV4TestSuite } from "./internal/signature.js";
 import { sqsTestSuite } from "./internal/sqs.js";
 import { eventBridgeTestSuite } from "./internal/event-bridge.js";
 import { lambdaTestSuite } from "./internal/lambda.js";
+import { dynamoDbTestSuite } from "./internal/dynamo-db.js";
 
 // Must know:
 //   * end2end tests such as these rely on the localstack
@@ -89,6 +90,11 @@ const testData = {
     },
   },
 
+  // DynamoDB tests specific data
+  dynamoDb: {
+    tableName: "test-jslib-aws-table",
+  },
+
   // Systems Manager tests specific data
   systemsManager: {
     testParameter: {
@@ -120,4 +126,5 @@ export default async function () {
   await kinesisTestSuite(testData);
   await eventBridgeTestSuite(testData);
   await lambdaTestSuite(testData);
+  await dynamoDbTestSuite(testData);
 }

--- a/tests/internal/dynamo-db.js
+++ b/tests/internal/dynamo-db.js
@@ -190,8 +190,10 @@ export async function dynamoDbTestSuite(data) {
   await asyncDescribe(
     "dynamoDb.putItem with a failing conditionExpression",
     async (expect) => {
-      // Arrange: seeded by the init script, untouched by other tests.
-      const key = { pk: { S: "tenant#1" }, sk: { S: "item#1" } };
+      // Arrange: a dedicated item, so this test's assumptions can't be
+      // broken by an unrelated change to a shared, widely-read item.
+      const key = { pk: { S: "tenant#1" }, sk: { S: "item#put-conditional" } };
+      await dynamoDb.putItem(tableName, { ...key, value: { S: "original" } });
 
       // Act
       let conditionalCheckError;
@@ -211,18 +213,25 @@ export async function dynamoDbTestSuite(data) {
       expect(conditionalCheckError.code).to.include(
         "ConditionalCheckFailedException",
       );
+      expect(conditionalCheckError.operation).to.equal("PutItem");
 
       // ...and the existing item was left untouched.
       const item = await dynamoDb.getItem(tableName, key);
-      expect(item.value.S).to.equal("alpha");
+      expect(item.value.S).to.equal("original");
     },
   );
 
   await asyncDescribe("dynamoDb.updateItem", async (expect) => {
+    // Arrange: an explicit starting value, so this test proves a real
+    // transition happened (rather than passing as a no-op on a repeat run
+    // against the same table, where the item might already be "updated").
+    const key = { pk: { S: "tenant#1" }, sk: { S: "item#update" } };
+    await dynamoDb.putItem(tableName, { ...key, value: { S: "original" } });
+
     // Act
     const updated = await dynamoDb.updateItem(
       tableName,
-      { pk: { S: "tenant#1" }, sk: { S: "item#update" } },
+      key,
       "SET #v = :v",
       {
         expressionAttributeNames: { "#v": "value" },
@@ -234,32 +243,25 @@ export async function dynamoDbTestSuite(data) {
     // Assert
     expect(updated.value.S).to.equal("updated");
 
-    const item = await dynamoDb.getItem(tableName, {
-      pk: { S: "tenant#1" },
-      sk: { S: "item#update" },
-    });
+    const item = await dynamoDb.getItem(tableName, key);
     expect(item.value.S).to.equal("updated");
   });
 
   await asyncDescribe("dynamoDb.deleteItem", async (expect) => {
-    // Arrange
-    const beforeDelete = await dynamoDb.getItem(tableName, {
-      pk: { S: "tenant#1" },
-      sk: { S: "item#delete" },
-    });
+    // Arrange: create the item to delete here, rather than relying on the
+    // init script's seed, so this test is safe to rerun against a table
+    // that's already been through a previous run of this same suite.
+    const key = { pk: { S: "tenant#1" }, sk: { S: "item#delete" } };
+    await dynamoDb.putItem(tableName, { ...key, value: { S: "to-delete" } });
+
+    const beforeDelete = await dynamoDb.getItem(tableName, key);
     expect(beforeDelete).to.not.be.undefined;
 
     // Act
-    await dynamoDb.deleteItem(tableName, {
-      pk: { S: "tenant#1" },
-      sk: { S: "item#delete" },
-    });
+    await dynamoDb.deleteItem(tableName, key);
 
     // Assert
-    const afterDelete = await dynamoDb.getItem(tableName, {
-      pk: { S: "tenant#1" },
-      sk: { S: "item#delete" },
-    });
+    const afterDelete = await dynamoDb.getItem(tableName, key);
     expect(afterDelete).to.be.undefined;
   });
 
@@ -292,6 +294,7 @@ export async function dynamoDbTestSuite(data) {
       expect(conditionalCheckError.code).to.include(
         "ConditionalCheckFailedException",
       );
+      expect(conditionalCheckError.operation).to.equal("DeleteItem");
 
       // Act: delete it for real, returning its previous attributes.
       const deleted = await dynamoDb.deleteItem(tableName, key, {
@@ -324,6 +327,7 @@ export async function dynamoDbTestSuite(data) {
       // Assert
       expect(getItemError).to.not.be.undefined;
       expect(getItemError).to.be.an.instanceOf(DynamoDBServiceError);
+      expect(getItemError.operation).to.equal("GetItem");
     },
   );
 }

--- a/tests/internal/dynamo-db.js
+++ b/tests/internal/dynamo-db.js
@@ -1,0 +1,157 @@
+import { asyncDescribe } from "./helpers.js";
+import { DynamoDBClient, DynamoDBServiceError } from "../../dist/dynamo-db.js";
+
+export async function dynamoDbTestSuite(data) {
+  const dynamoDb = new DynamoDBClient(data.awsConfig);
+  const tableName = data.dynamoDb.tableName;
+
+  await asyncDescribe("dynamoDb.getItem", async (expect) => {
+    // Act
+    const item = await dynamoDb.getItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#1" },
+    });
+
+    // Assert
+    expect(item).to.not.be.undefined;
+    expect(item.value.S).to.equal("alpha"); // as seeded by the init script
+  });
+
+  await asyncDescribe("dynamoDb.getItem non-existent item", async (expect) => {
+    // Act
+    const item = await dynamoDb.getItem(tableName, {
+      pk: { S: "tenant#does-not-exist" },
+      sk: { S: "item#1" },
+    });
+
+    // Assert
+    expect(item).to.be.undefined;
+  });
+
+  await asyncDescribe("dynamoDb.query", async (expect) => {
+    // Act
+    const result = await dynamoDb.query(
+      tableName,
+      "pk = :pk",
+      {
+        expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+      },
+    );
+
+    // Assert
+    expect(result.count).to.equal(4); // item#1, item#2, item#update, item#delete
+    expect(result.items).to.have.length(4);
+    expect(result.items.map((i) => i.sk.S)).to.include("item#1");
+    expect(result.items.map((i) => i.sk.S)).to.include("item#2");
+  });
+
+  await asyncDescribe("dynamoDb.scan", async (expect) => {
+    // Act
+    const result = await dynamoDb.scan(tableName);
+
+    // Assert
+    expect(result.count).to.equal(5); // all items seeded by the init script
+    expect(result.items).to.have.length(5);
+  });
+
+  await asyncDescribe("dynamoDb.putItem", async (expect) => {
+    // Act
+    await dynamoDb.putItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#put" },
+      value: { S: "created-by-test" },
+    });
+
+    // Assert
+    const item = await dynamoDb.getItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#put" },
+    });
+    expect(item.value.S).to.equal("created-by-test");
+  });
+
+  await asyncDescribe(
+    "dynamoDb.putItem returns previous attributes",
+    async (expect) => {
+      // Act
+      const previous = await dynamoDb.putItem(
+        tableName,
+        {
+          pk: { S: "tenant#1" },
+          sk: { S: "item#put" },
+          value: { S: "overwritten-by-test" },
+        },
+        { returnValues: "ALL_OLD" },
+      );
+
+      // Assert
+      expect(previous).to.not.be.undefined;
+      expect(previous.value.S).to.equal("created-by-test");
+    },
+  );
+
+  await asyncDescribe("dynamoDb.updateItem", async (expect) => {
+    // Act
+    const updated = await dynamoDb.updateItem(
+      tableName,
+      { pk: { S: "tenant#1" }, sk: { S: "item#update" } },
+      "SET #v = :v",
+      {
+        expressionAttributeNames: { "#v": "value" },
+        expressionAttributeValues: { ":v": { S: "updated" } },
+        returnValues: "ALL_NEW",
+      },
+    );
+
+    // Assert
+    expect(updated.value.S).to.equal("updated");
+
+    const item = await dynamoDb.getItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#update" },
+    });
+    expect(item.value.S).to.equal("updated");
+  });
+
+  await asyncDescribe("dynamoDb.deleteItem", async (expect) => {
+    // Arrange
+    const beforeDelete = await dynamoDb.getItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#delete" },
+    });
+    expect(beforeDelete).to.not.be.undefined;
+
+    // Act
+    await dynamoDb.deleteItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#delete" },
+    });
+
+    // Assert
+    const afterDelete = await dynamoDb.getItem(tableName, {
+      pk: { S: "tenant#1" },
+      sk: { S: "item#delete" },
+    });
+    expect(afterDelete).to.be.undefined;
+  });
+
+  await asyncDescribe(
+    "dynamoDb.getItem from non-existent table",
+    async (expect) => {
+      // Act
+      let getItemError;
+      try {
+        await dynamoDb.getItem("non-existent-table", {
+          pk: { S: "tenant#1" },
+          sk: { S: "item#1" },
+        });
+      } catch (error) {
+        getItemError = error;
+      }
+
+      // Assert
+      expect(getItemError).to.not.be.undefined;
+      expect(getItemError).to.be.an.instanceOf(DynamoDBServiceError);
+    },
+  );
+}

--- a/tests/internal/dynamo-db.js
+++ b/tests/internal/dynamo-db.js
@@ -45,6 +45,71 @@ export async function dynamoDbTestSuite(data) {
     expect(result.items.map((i) => i.sk.S)).to.include("item#2");
   });
 
+  await asyncDescribe(
+    "dynamoDb.query pagination via lastEvaluatedKey",
+    async (expect) => {
+      // Act: fetch a single item at a time.
+      const firstPage = await dynamoDb.query(tableName, "pk = :pk", {
+        expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+        limit: 1,
+      });
+
+      // Assert: exactly one item, and a token to continue from.
+      expect(firstPage.items).to.have.length(1);
+      expect(firstPage.lastEvaluatedKey).to.not.be.undefined;
+
+      // Act: continue from where the first page left off.
+      const secondPage = await dynamoDb.query(tableName, "pk = :pk", {
+        expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+        limit: 1,
+        exclusiveStartKey: firstPage.lastEvaluatedKey,
+      });
+
+      // Assert: the second page picks up a different item than the first.
+      expect(secondPage.items).to.have.length(1);
+      expect(secondPage.items[0].sk.S).to.not.equal(firstPage.items[0].sk.S);
+    },
+  );
+
+  await asyncDescribe(
+    "dynamoDb.query with filterExpression",
+    async (expect) => {
+      // Act: match the whole partition, then filter down post-fetch to a
+      // single item by an attribute value that is not part of the key.
+      // "value" is a DynamoDB reserved word, hence the name placeholder.
+      const result = await dynamoDb.query(tableName, "pk = :pk", {
+        expressionAttributeNames: { "#v": "value" },
+        expressionAttributeValues: {
+          ":pk": { S: "tenant#1" },
+          ":v": { S: "alpha" },
+        },
+        filterExpression: "#v = :v",
+      });
+
+      // Assert: the filter narrowed the results down to the one matching
+      // item, even though more items than that were scanned to find it.
+      expect(result.items).to.have.length(1);
+      expect(result.items[0].sk.S).to.equal("item#1");
+      expect(result.scannedCount).to.be.above(result.count);
+    },
+  );
+
+  await asyncDescribe("dynamoDb.query scanIndexForward", async (expect) => {
+    // Act: fetch the partition in default (ascending) order, then reversed.
+    const ascending = await dynamoDb.query(tableName, "pk = :pk", {
+      expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+    });
+    const descending = await dynamoDb.query(tableName, "pk = :pk", {
+      expressionAttributeValues: { ":pk": { S: "tenant#1" } },
+      scanIndexForward: false,
+    });
+
+    // Assert: the two orders are the reverse of one another.
+    const ascendingKeys = ascending.items.map((i) => i.sk.S);
+    const descendingKeys = descending.items.map((i) => i.sk.S);
+    expect(descendingKeys).to.deep.equal([...ascendingKeys].reverse());
+  });
+
   await asyncDescribe("dynamoDb.scan", async (expect) => {
     // Act
     const result = await dynamoDb.scan(tableName);
@@ -73,20 +138,54 @@ export async function dynamoDbTestSuite(data) {
   await asyncDescribe(
     "dynamoDb.putItem returns previous attributes",
     async (expect) => {
+      // Arrange
+      const key = { pk: { S: "tenant#1" }, sk: { S: "item#put-returns-old" } };
+      await dynamoDb.putItem(tableName, {
+        ...key,
+        value: { S: "created-by-test" },
+      });
+
       // Act
       const previous = await dynamoDb.putItem(
         tableName,
-        {
-          pk: { S: "tenant#1" },
-          sk: { S: "item#put" },
-          value: { S: "overwritten-by-test" },
-        },
+        { ...key, value: { S: "overwritten-by-test" } },
         { returnValues: "ALL_OLD" },
       );
 
       // Assert
       expect(previous).to.not.be.undefined;
       expect(previous.value.S).to.equal("created-by-test");
+    },
+  );
+
+  await asyncDescribe(
+    "dynamoDb.putItem with a failing conditionExpression",
+    async (expect) => {
+      // Arrange: seeded by the init script, untouched by other tests.
+      const key = { pk: { S: "tenant#1" }, sk: { S: "item#1" } };
+
+      // Act
+      let conditionalCheckError;
+      try {
+        await dynamoDb.putItem(
+          tableName,
+          { ...key, value: { S: "should-not-be-written" } },
+          { conditionExpression: "attribute_not_exists(pk)" },
+        );
+      } catch (error) {
+        conditionalCheckError = error;
+      }
+
+      // Assert: the condition failed since the item already exists...
+      expect(conditionalCheckError).to.not.be.undefined;
+      expect(conditionalCheckError).to.be.an.instanceOf(DynamoDBServiceError);
+      expect(conditionalCheckError.code).to.include(
+        "ConditionalCheckFailedException",
+      );
+
+      // ...and the existing item was left untouched.
+      const item = await dynamoDb.getItem(tableName, key);
+      expect(item.value.S).to.equal("alpha");
     },
   );
 

--- a/tests/internal/dynamo-db.js
+++ b/tests/internal/dynamo-db.js
@@ -28,6 +28,29 @@ export async function dynamoDbTestSuite(data) {
     expect(item).to.be.undefined;
   });
 
+  await asyncDescribe(
+    "dynamoDb.getItem with consistentRead and projectionExpression",
+    async (expect) => {
+      // Act: project only the "value" attribute (itself a reserved word,
+      // hence the name placeholder), not the primary key.
+      const item = await dynamoDb.getItem(
+        tableName,
+        { pk: { S: "tenant#1" }, sk: { S: "item#1" } },
+        {
+          consistentRead: true,
+          projectionExpression: "#v",
+          expressionAttributeNames: { "#v": "value" },
+        },
+      );
+
+      // Assert: only the projected attribute comes back.
+      expect(item).to.not.be.undefined;
+      expect(item.value.S).to.equal("alpha");
+      expect(item.pk).to.be.undefined;
+      expect(item.sk).to.be.undefined;
+    },
+  );
+
   await asyncDescribe("dynamoDb.query", async (expect) => {
     // Act
     const result = await dynamoDb.query(
@@ -38,9 +61,9 @@ export async function dynamoDbTestSuite(data) {
       },
     );
 
-    // Assert
-    expect(result.count).to.equal(4); // item#1, item#2, item#update, item#delete
-    expect(result.items).to.have.length(4);
+    // Assert: the items seeded by the init script that no other test ever
+    // removes are present. The exact count isn't asserted, since other
+    // tests add and remove items within this same partition.
     expect(result.items.map((i) => i.sk.S)).to.include("item#1");
     expect(result.items.map((i) => i.sk.S)).to.include("item#2");
   });
@@ -114,9 +137,15 @@ export async function dynamoDbTestSuite(data) {
     // Act
     const result = await dynamoDb.scan(tableName);
 
-    // Assert
-    expect(result.count).to.equal(5); // all items seeded by the init script
-    expect(result.items).to.have.length(5);
+    // Assert: the items seeded by the init script that no other test ever
+    // removes are present, across both partitions. The exact count isn't
+    // asserted, since other tests add and remove items in the table.
+    const hasItem = (pk, sk) =>
+      result.items.some((i) => i.pk.S === pk && i.sk.S === sk);
+
+    expect(hasItem("tenant#1", "item#1")).to.be.true;
+    expect(hasItem("tenant#1", "item#2")).to.be.true;
+    expect(hasItem("tenant#2", "item#1")).to.be.true;
   });
 
   await asyncDescribe("dynamoDb.putItem", async (expect) => {
@@ -233,6 +262,50 @@ export async function dynamoDbTestSuite(data) {
     });
     expect(afterDelete).to.be.undefined;
   });
+
+  await asyncDescribe(
+    "dynamoDb.deleteItem with returnValues and a failing conditionExpression",
+    async (expect) => {
+      // Arrange
+      const key = {
+        pk: { S: "tenant#1" },
+        sk: { S: "item#delete-conditional" },
+      };
+      await dynamoDb.putItem(tableName, {
+        ...key,
+        value: { S: "to-be-deleted" },
+      });
+
+      // Act: a delete that should be rejected...
+      let conditionalCheckError;
+      try {
+        await dynamoDb.deleteItem(tableName, key, {
+          conditionExpression: "attribute_not_exists(pk)",
+        });
+      } catch (error) {
+        conditionalCheckError = error;
+      }
+
+      // Assert: ...because the item exists, so nothing was deleted.
+      expect(conditionalCheckError).to.not.be.undefined;
+      expect(conditionalCheckError).to.be.an.instanceOf(DynamoDBServiceError);
+      expect(conditionalCheckError.code).to.include(
+        "ConditionalCheckFailedException",
+      );
+
+      // Act: delete it for real, returning its previous attributes.
+      const deleted = await dynamoDb.deleteItem(tableName, key, {
+        returnValues: "ALL_OLD",
+      });
+
+      // Assert
+      expect(deleted).to.not.be.undefined;
+      expect(deleted.value.S).to.equal("to-be-deleted");
+
+      const afterDelete = await dynamoDb.getItem(tableName, key);
+      expect(afterDelete).to.be.undefined;
+    },
+  );
 
   await asyncDescribe(
     "dynamoDb.getItem from non-existent table",


### PR DESCRIPTION
Adding support for DynamoDB query and CRUD operations

  - [x] Service implemented in src/internal/, re-exported via src/{service}.ts and src/index.ts
  - [x] Build entry point added
  - [x] Tests added and registered in tests/index.js
  - [x] LocalStack seed script if needed
  - [x] Documentation (README + example)
